### PR TITLE
Adding an extra check for abbreviations allows for tabbing out of tinyMCE

### DIFF
--- a/common/content/editor.js
+++ b/common/content/editor.js
@@ -446,7 +446,7 @@ const Editor = Module("editor", {
         if (!textbox)
             return false;
         let text      = textbox.value;
-        if (typeof(text) !== "string")
+        if (typeof text !== "string")
             return false;
 
         let currStart = textbox.selectionStart;


### PR DESCRIPTION
This fixed #12 (the issue I created).

Also replaced tabs in file to spaces.
