### PR TITLE
Exclude dotfiles in Make.

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -3,7 +3,7 @@
 TOP           = $(shell pwd)
 OS            = $(shell uname -s)
 BUILD_DATE    = $(shell date "+%Y/%m/%d %H:%M:%S")
-COMMON_DIR    = $(TOP)/../common
+COMMON_DIR    = ../common
 GOOGLE_PROJ   = vimperator-labs
 GOOGLE	      = https://$(GOOGLE_PROJ).googlecode.com/files
 
@@ -103,7 +103,7 @@ xpi:
 		echo "locale liberator $(LOCALE) common/locale/$(LOCALE)/" >> $(XPI_PATH)/chrome.manifest; \
 	fi
 	# Copy components and modules directories
-	find $(XPI_DIRS) -follow -type f ! -name ".*" -print0 | xargs -0i $(CP) {} -t $(XPI_PATH) || true
+	find $(XPI_DIRS) -follow -type f ! -name ".*" -print0 | xargs -0i $(CP) --parents {} -t $(XPI_PATH) || true
 	# Copy all chrome files, from both commmon/ and vimperator/ folders
 	cd $(COMMON_DIR) && find $(COMMON_CHROME_DIRS) -follow -type f ! -name ".*" -print0 | xargs -0i $(CP) --parents {} -t $(XPI_PATH)/common || true
 	find $(CHROME_DIRS) -follow -type f ! -name ".*" -print0 | xargs -0i $(CP) --parents {} -t $(XPI_PATH) || true


### PR DESCRIPTION
This change will make dotfiles(e.g. .protocols.js.swp) not included the XPI when you build. Working with the editor to generate the swap file will be easier.

I've tested this in Cygwin(on Windows 8.1) and CentOS 7. I want operation check in a BSD environment(e.g. MacOS X) particularly.
