### PR TITLE
Fix make in Mac

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -34,8 +34,10 @@ CURL = curl
 B64ENCODE = base64
 # Mac OS X's sed and cp is not run because BSD's syntax
 # use make -e SED=gsed CP=gcp ...
-SED  ?= sed
-CP   ?= cp
+SED   ?= sed
+CP    ?= cp
+FIND  ?= find
+XARGS ?= xargs
 
 .SILENT:
 
@@ -103,13 +105,13 @@ xpi:
 		echo "locale liberator $(LOCALE) common/locale/$(LOCALE)/" >> $(XPI_PATH)/chrome.manifest; \
 	fi
 	# Copy components and modules directories
-	find $(XPI_DIRS) -follow -type f ! -name ".*" -print0 | xargs -0i $(CP) --parents {} -t $(XPI_PATH) || true
+	$(FIND) $(XPI_DIRS) -follow -type f ! -name ".*" -print0 | $(XARGS) -0i $(CP) --parents {} -t $(XPI_PATH) || true
 	# Copy all chrome files, from both commmon/ and vimperator/ folders
-	cd $(COMMON_DIR) && find $(COMMON_CHROME_DIRS) -follow -type f ! -name ".*" -print0 | xargs -0i $(CP) --parents {} -t $(XPI_PATH)/common || true
-	find $(CHROME_DIRS) -follow -type f ! -name ".*" -print0 | xargs -0i $(CP) --parents {} -t $(XPI_PATH) || true
+	cd $(COMMON_DIR) && $(FIND) $(COMMON_CHROME_DIRS) -follow -type f ! -name ".*" -print0 | $(XARGS) -0i $(CP) --parents {} -t $(XPI_PATH)/common || true
+	$(FIND) $(CHROME_DIRS) -follow -type f ! -name ".*" -print0 | $(XARGS) -0i $(CP) --parents {} -t $(XPI_PATH) || true
 	# TODO: Replace ###VERSION### tags
 	@echo "Replacing ###VERSION### and ###DATE### tags"
-	find $(XPI_PATH) -type f ! -name "*.png" -exec $(SED) -i -e "s,###VERSION###,$(VERSION),g" -e "s,###DATE###,$(BUILD_DATE),g" {} \;
+	$(FIND) $(XPI_PATH) -type f ! -name "*.png" -exec $(SED) -i -e "s,###VERSION###,$(VERSION),g" -e "s,###DATE###,$(BUILD_DATE),g" {} \;
 	# Zip the whole directory and remove dist folder
 	cd $(XPI_PATH) && zip -9r ../$(XPI_NAME).xpi *
 	rm -rf $(XPI_PATH)


### PR DESCRIPTION
I noticed vimperator make failure in Mac.

Because Mac has BSD findutils. but vimperator expected GNU findutils.

for example.
https://github.com/vimperator/vimperator-labs/blob/master/common/Makefile#L106

Same problem has cp and sed. its escape that defined variable in Makefile.
https://github.com/vimperator/vimperator-labs/blob/master/common/Makefile#L35

I wrapped `find` and `xargs` for replaceable.

I checked make success when Install GNU-findutils, GNU-sed, GNU-coreutils and run this make commands.

`make -e XARGS=gxargs FIND=gfind SED=gsed CP=gcp -C vimperator xpi`

---

make failure logs(use default `xargs` and `find`)

```
% make -C vimperator xpi
Building XPI...
cp: -t: No such file or directory
Update chrome.manifest for paths used inside the XPI...
xargs: illegal option -- i
usage: xargs [-0opt] [-E eofstr] [-I replstr [-R replacements]] [-J replstr]
             [-L number] [-n number [-x]] [-P maxprocs] [-s size]
             [utility [argument ...]]
```

make success logs

```
% make -e XARGS=gxargs FIND=gfind SED=gsed CP=gcp -C vimperator xpi
Building XPI...
Update chrome.manifest for paths used inside the XPI...
Replacing ###VERSION### and ###DATE### tags
updating: AUTHORS (deflated 42%)
updating: License.txt (deflated 42%)
updating: NEWS (deflated 64%)
updating: TODO (deflated 48%)
updating: chrome.manifest (deflated 69%)
updating: common/ (stored 0%)
updating: common/content/ (stored 0%)
updating: common/content/abbreviations.js (deflated 71%)
updating: common/content/autocommands.js (deflated 72%)
updating: common/content/base.js (deflated 69%)
updating: common/content/bindings.xml (deflated 55%)
updating: common/content/bookmarks.js (deflated 74%)
updating: common/content/browser.js (deflated 74%)
updating: common/content/buffer.js (deflated 76%)
updating: common/content/buffer.xhtml (deflated 32%)
updating: common/content/commandline.js (deflated 76%)
updating: common/content/commands.js (deflated 75%)
updating: common/content/completion.js (deflated 73%)
updating: common/content/configbase.js (deflated 61%)
updating: common/content/editor.js (deflated 79%)
updating: common/content/eval.js (deflated 37%)
updating: common/content/events.js (deflated 74%)
updating: common/content/finder.js (deflated 73%)
updating: common/content/help-single.xsl (deflated 62%)
updating: common/content/help.css (deflated 63%)
updating: common/content/help.js (deflated 41%)
updating: common/content/help.xsl (deflated 83%)
updating: common/content/hints.js (deflated 75%)
updating: common/content/history.js (deflated 76%)
updating: common/content/io.js (deflated 73%)
updating: common/content/javascript.js (deflated 72%)
updating: common/content/liberator-overlay.js (deflated 59%)
updating: common/content/liberator.js (deflated 75%)
updating: common/content/liberator.xul (deflated 73%)
updating: common/content/mappings.js (deflated 76%)
updating: common/content/marks.js (deflated 71%)
updating: common/content/modes.js (deflated 68%)
updating: common/content/modules.js (deflated 65%)
updating: common/content/options.js (deflated 78%)
updating: common/content/preferences.xul (deflated 39%)
updating: common/content/quickmarks.js (deflated 67%)
updating: common/content/sanitizer.js (deflated 72%)
updating: common/content/services.js (deflated 72%)
updating: common/content/statusline.js (deflated 71%)
updating: common/content/style.js (deflated 75%)
updating: common/content/tabs.js (deflated 78%)
updating: common/content/template.js (deflated 70%)
updating: common/content/util.js (deflated 70%)
updating: common/content/x-click-but21.png (deflated 8%)
updating: common/locale/ (stored 0%)
updating: common/locale/en-US/ (stored 0%)
updating: common/locale/en-US/all.xml (deflated 66%)
updating: common/locale/en-US/autocommands.xml (deflated 65%)
updating: common/locale/en-US/browsing.xml (deflated 74%)
updating: common/locale/en-US/buffer.xml (deflated 78%)
updating: common/locale/en-US/cmdline.xml (deflated 70%)
updating: common/locale/en-US/developer.xml (deflated 64%)
updating: common/locale/en-US/eval.xml (deflated 65%)
updating: common/locale/en-US/gui.xml (deflated 70%)
updating: common/locale/en-US/hints.xml (deflated 65%)
updating: common/locale/en-US/insert.xml (deflated 55%)
updating: common/locale/en-US/map.xml (deflated 74%)
updating: common/locale/en-US/marks.xml (deflated 76%)
updating: common/locale/en-US/message.xml (deflated 63%)
updating: common/locale/en-US/options.xml (deflated 76%)
updating: common/locale/en-US/pattern.xml (deflated 64%)
updating: common/locale/en-US/print.xml (deflated 53%)
updating: common/locale/en-US/repeat.xml (deflated 68%)
updating: common/locale/en-US/starting.xml (deflated 65%)
updating: common/locale/en-US/styling.xml (deflated 72%)
updating: common/locale/en-US/tabs.xml (deflated 74%)
updating: common/locale/en-US/various.xml (deflated 67%)
updating: common/modules/ (stored 0%)
updating: common/modules/storage.jsm (deflated 69%)
updating: common/modules/template-tag.js (deflated 82%)
updating: common/modules/template.js (deflated 79%)
updating: common/skin/ (stored 0%)
updating: common/skin/liberator.css (deflated 71%)
updating: common/skin/prompt.png (deflated 5%)
updating: components/ (stored 0%)
updating: components/about-handler.js (deflated 47%)
updating: components/commandline-handler.js (deflated 47%)
updating: components/protocols.js (deflated 72%)
updating: content/ (stored 0%)
updating: content/about.html (deflated 53%)
updating: content/about_background.png (deflated 0%)
updating: content/config.js (deflated 71%)
updating: content/ignorekeys.js (deflated 73%)
updating: content/liberator.dtd (deflated 56%)
updating: content/logo.png (stored 0%)
updating: content/tabgroup.js (deflated 76%)
updating: content/vimperator.svg (deflated 63%)
updating: content/vimperator.xul (deflated 69%)
updating: install.rdf (deflated 55%)
updating: locale/ (stored 0%)
updating: locale/en-US/ (stored 0%)
updating: locale/en-US/all.xml (deflated 38%)
updating: locale/en-US/autocommands.xml (deflated 67%)
updating: locale/en-US/browsing.xml (deflated 67%)
updating: locale/en-US/gui.xml (deflated 63%)
updating: locale/en-US/intro.xml (deflated 62%)
updating: locale/en-US/liberator.dtd (deflated 13%)
updating: locale/en-US/options.xml (deflated 55%)
updating: locale/en-US/tabs.xml (deflated 77%)
updating: locale/en-US/tutorial.xml (deflated 62%)
updating: skin/ (stored 0%)
updating: skin/about.css (deflated 50%)
updating: skin/icon.png (stored 0%)
SUCCESS: ../downloads/vimperator-3.8.2.xpi
```
