### PR TITLE
Fix wrong highlight group of `o' tag in help.xsl

### DIFF
--- a/common/content/help.xsl
+++ b/common/content/help.xsl
@@ -257,7 +257,7 @@
     </xsl:template>
 
     <xsl:template match="liberator:o" mode="pass-2">
-        <span liberator:highlight="HelpOption">
+        <span liberator:highlight="HelpOpt">
             <xsl:call-template name="linkify-tag">
                 <xsl:with-param name="contents" select='concat("&#39;", text(), "&#39;")'/>
             </xsl:call-template>


### PR DESCRIPTION
[As documented](https://github.com/vimperator/vimperator-labs/blob/master/common/locale/en-US/developer.xml#L115), `o` help tag should be highlighted with `HelpOpt`, not `HelpOption`.
