### PR TITLE
Fix find results not displayed after hitting enter

### DIFF
--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -120,6 +120,7 @@ const Finder = Module("finder", {
         this._processUserPattern(str);
         let result = fastFind.find(str, this._linksOnly);
         window.gFindBar._findField.value = str;
+        this._displayFindResult(result, this._backwards);
     } :
     // FIXME: remove when minVersion >= 25
     function (str) {


### PR DESCRIPTION
Display a visual feedback so that the user knows if there's any results for the search. Currently the user has to press extra n/N in order to get any feedback. Related to #30 
