### PR TITLE
Support TabMixPlus's "Open (New) Tab Next to Current" option

### DIFF
--- a/common/content/liberator.js
+++ b/common/content/liberator.js
@@ -802,6 +802,7 @@ const Liberator = Module("liberator", {
                 else
                     [url, postdata] = Array.concat(urls);
 
+                newtab = !url;
                 if (!url)
                     url = window.BROWSER_NEW_TAB_URL || "about:blank";
 
@@ -820,7 +821,8 @@ const Liberator = Module("liberator", {
 
                     options.withContext(function () {
                         options.setPref("browser.tabs.loadInBackground", true);
-                        browser.loadOneTab(url, null, null, postdata, where == liberator.NEW_BACKGROUND_TAB);
+                        // This may not be exactly right, but it works well enough for me.
+                        browser.loadOneTab(url, { referrerURI: null, charset: null, postData: postdata, inBackground: where == liberator.NEW_BACKGROUND_TAB, relatedToCurrent: newtab ? options.getPref("extensions.tabmix.openNewTabNext") : options.getPref("extensions.tabmix.openTabNext") } );
                     });
                     break;
 


### PR DESCRIPTION
Support TabMixPlus's "Open Tab Next to Current" and "Open New Tab Next to Current" options.

Very interested in fixing this up so that it's customisable (and so don't break behaviour for other users) and/or doesn't break if TMP isn't installed, and so can be merged into the main code. Feedback very very welcome.