### PR TITLE
Check if firstHint is null in hints.js

### DIFF
--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -496,6 +496,10 @@ const Hints = Module("hints", {
             }
         }
 
+        if (firstHint === null) {
+            return false;
+        }
+
         this._tabNavigation[firstHint].prev = lastHint;
         this._tabNavigation[lastHint].next = firstHint;
 


### PR DESCRIPTION
When hints are opened and closed too quickly it throws
`TypeError: this._tabNavigation[firstHint] is undefined`

Can be reproduced by hitting f followed by Esc.
