### PR TITLE
Updated tutorial

### DIFF
--- a/vimperator/locale/en-US/tutorial.xml
+++ b/vimperator/locale/en-US/tutorial.xml
@@ -73,8 +73,7 @@
 </code>
 
 <p>
-    Finally, in addition to the help system itself, <ex>:exusage</ex>, <ex>:viusage</ex>
-    and <ex>:optionusage</ex> are useful quick-reference commands.
+    Finally, in addition to the help system itself, <ex>:usage</ex> is a useful quick-reference command.
 </p>
 
 <h2 tag="living-mouseless">Mouseless</h2>


### PR DESCRIPTION
According to the [change log](https://github.com/vimperator/vimperator-labs/blob/32d5a35a3b75319a365f97b94a8b38887f11f6ea/vimperator/NEWS) for version 3.1:

> IMPORTANT: :viusage, :exusage and :optionusage (and the manually created
> index of all commands in the helpfile) have been replaced by a single
> :usage command.

So I just updated the outdated xml file.
