### PR TITLE
Fixed wiki link

### DIFF
--- a/vimperator/locale/en-US/tutorial.xml
+++ b/vimperator/locale/en-US/tutorial.xml
@@ -325,7 +325,7 @@
     &liberator.appname; has an energetic and growing user base. If you've run into a problem
     that you can't seem to solve with &liberator.appname;, or if you think you might have
     found a bug, please let us know! There is support available on the
-    <link topic="https://github.com/vimperator/vimperator-labs/wiki">wiki</link>
+    <link topic="https://github.com/vimperator/vimperator-labs/issues">wiki</link>
     or in the <link topic="irc://irc.freenode.net/vimperator">#vimperator</link> IRC
     channel on <link topic="http://freenode.net/">freenode</link>.
 </p>


### PR DESCRIPTION
The wiki link provided in tutorial.xml is 'http://code.google.com/p/vimperator-labs/w/list?q=label%3Aproject-vimperator', now that vimperator had moved from google code to github, so i think it's better to fix it in tutorial.xml, instead of show that page telling people it's not there anymore. 
