### PR TITLE
Fixed a typo in a help page

### DIFF
--- a/common/locale/en-US/map.xml
+++ b/common/locale/en-US/map.xml
@@ -85,7 +85,7 @@
 
 <item>
     <tags>:unm :unmap</tags>
-    <spec>:map <a>lhs</a> <a>rhs</a></spec>
+    <spec>:unm<oa>ap</oa> <a>lhs</a> <a>rhs</a></spec>
     <tags>:nun :nunmap</tags>
     <spec>:nun<oa>map</oa> <a>lhs</a> <a>rhs</a></spec>
     <tags>:vun :vunmap</tags>


### PR DESCRIPTION
There's a small typo in the command for removing key mappings.
