### PR TITLE
fix: don't display help message on click event

### DIFF
--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -852,6 +852,9 @@ const CommandLine = Module("commandline", {
                     break;
             }
 
+        }
+
+        if (event.type == "click") {
             return;
         }
 


### PR DESCRIPTION
Accidentally clicking on the search suggestions area causes annoying help message `Y: yank | ;o: follow hint | ESC/q: quit` to display which covers the whole command line.
