### PR TITLE
Ignore disabled input elements in hinttags

### DIFF
--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -1254,7 +1254,7 @@ const Hints = Module("hints", {
     },
     options: function () {
         const DEFAULT_HINTTAGS =
-            util.makeXPath(["input[not(@type='hidden')]", "a", "area", "iframe", "textarea", "button", "select"])
+            util.makeXPath(["input[not(@type='hidden' or @disabled)]", "a", "area", "iframe", "textarea", "button", "select"])
                 + " | //*[@onclick or @onmouseover or @onmousedown or @onmouseup or @oncommand or @role='link'or @role='button' or @role='checkbox' or @role='combobox' or @role='listbox' or @role='listitem' or @role='menuitem' or @role='menuitemcheckbox' or @role='menuitemradio' or @role='option' or @role='radio' or @role='scrollbar' or @role='slider' or @role='spinbutton' or @role='tab' or @role='textbox' or @role='treeitem' or @tabindex]"
                 + (config.name == "Muttator" ?
                     " | //xhtml:div[@class='wrappedsender']/xhtml:div[contains(@class,'link')]" :

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -607,7 +607,7 @@
     <tags>'ht' 'hinttags'</tags>
     <spec>'hinttags' 'ht'</spec>
     <type>string</type>
-    <default>//input[not(@type='hidden')] | //xhtml:input[not(@type='hidden')] | //a | //xhtml:a | //area | //xhtml:area | //iframe | //xhtml:iframe | //textarea | //xhtml:textarea | //button | //xhtml:button | //select | //xhtml:select | //*[@onclick or @onmouseover or @onmousedown or @onmouseup or @oncommand or @role='link'or @role='button' or @role='checkbox' or @role='combobox' or @role='listbox' or @role='listitem' or @role='menuitem' or @role='menuitemcheckbox' or @role='menuitemradio' or @role='option' or @role='radio' or @role='scrollbar' or @role='slider' or @role='spinbutton' or @role='tab' or @role='textbox' or @role='treeitem' or @tabindex]</default>
+    <default>//input[not(@type='hidden' or @disabled)] | //xhtml:input[not(@type='hidden')] | //a | //xhtml:a | //area | //xhtml:area | //iframe | //xhtml:iframe | //textarea | //xhtml:textarea | //button | //xhtml:button | //select | //xhtml:select | //*[@onclick or @onmouseover or @onmousedown or @onmouseup or @oncommand or @role='link'or @role='button' or @role='checkbox' or @role='combobox' or @role='listbox' or @role='listitem' or @role='menuitem' or @role='menuitemcheckbox' or @role='menuitemradio' or @role='option' or @role='radio' or @role='scrollbar' or @role='slider' or @role='spinbutton' or @role='tab' or @role='textbox' or @role='treeitem' or @tabindex]</default>
     <description>
         <p>XPath string of hintable elements activated by <k>f</k> and <k>F</k></p>
     </description>


### PR DESCRIPTION
A disabled input element is unusable and un-clickable. There's no point
to highlight it.

Fixes #126 (Vimperator mark hint under disabled input fields)