### PR TITLE
fix minor typos in hints.xml

### DIFF
--- a/common/locale/en-US/hints.xml
+++ b/common/locale/en-US/hints.xml
@@ -76,7 +76,7 @@ tedious unless you always visit the first link on a page.
             <li><tag>;s</tag> <em>s</em> to save a link's destination</li>
             <li><tag>;S</tag> <em>S</em> to save a media object</li>
             <li><tag>;a</tag> <em>a</em> to save a link's destination (prompting for save location)</li>
-            <li><tag>;A</tag> <em>B</em> to save a media object (prompting for save location)</li>
+            <li><tag>;A</tag> <em>A</em> to save a media object (prompting for save location)</li>
             <li><tag>;f</tag> <em>f</em> to focus a frame</li>
             <li><tag>;o</tag> <em>o</em> to open its location in the current tab</li>
             <li><tag>;t</tag> <em>t</em> to open its location in a new tab</li>
@@ -93,7 +93,7 @@ tedious unless you always visit the first link on a page.
             <li><tag>;c</tag> <em>c</em> to open its context menu</li>
             <li><tag>;i</tag> <em>i</em> to open a media object</li>
             <li><tag>;I</tag> <em>I</em> to open a media object in a new tab</li>
-            <li><tag>;x</tag> <em>A</em> to display an element's title text, or alt text if none.</li>
+            <li><tag>;x</tag> <em>x</em> to display an element's title text, or alt text if none.</li>
         </ul>
 
         <p>


### PR DESCRIPTION
Small typo in the en-US version of the hints help page. The help text on a couple of the commands doesn't correspond to the actual command.