### PR TITLE
Fix command history and search history in 'per-window private mode'

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -24,7 +24,7 @@ const Events = Module("events", {
 
         this.sessionListeners = [];
 
-        this._macros = storage.newMap("macros", { store: true, privateData: true });
+        this._macros = storage.newMap("macros", { store: true });
 
         // NOTE: the order of ["Esc", "Escape"] or ["Escape", "Esc"]
         //       matters, so use that string as the first item, that you

--- a/common/content/liberator.js
+++ b/common/content/liberator.js
@@ -254,6 +254,25 @@ const Liberator = Module("liberator", {
         window.dump(msg.replace(/^./gm, ("config" in modules && config.name.toLowerCase()) + ": $&"));
     },
 
+    isPrivateWindow: function () {
+        return window.QueryInterface(Ci.nsIInterfaceRequestor)
+                     .getInterface(Ci.nsIWebNavigation)
+                     .QueryInterface(Ci.nsILoadContext)
+                     .usePrivateBrowsing;
+    },
+
+    windowID: function() {
+        return window.QueryInterface(Components.interfaces.nsIInterfaceRequestor)
+                     .getInterface(Components.interfaces.nsIDOMWindowUtils)
+                     .outerWindowID;
+
+    },
+
+    storeName: function(mode, isPrivate) {
+        let prefix = isPrivate ? "private-" + this.windowID() + "-" : "";
+        return prefix + "history-" + mode ;
+    },
+
     /**
      * Outputs a plain message to the command line.
      *
@@ -1171,10 +1190,7 @@ const Liberator = Module("liberator", {
                         win.setAttribute("titlemodifier_normal", value);
                         win.setAttribute("titlemodifier_privatebrowsing", value + suffix);
 
-                        if (window.QueryInterface(Ci.nsIInterfaceRequestor)
-                                  .getInterface(Ci.nsIWebNavigation)
-                                  .QueryInterface(Ci.nsILoadContext)
-                                  .usePrivateBrowsing) {
+                        if (liberator.isPrivateWindow()) {
                             win.setAttribute("titlemodifier", value + suffix);
                         }
                         else

--- a/common/content/marks.js
+++ b/common/content/marks.js
@@ -11,8 +11,8 @@ const Marks = Module("marks", {
     requires: ["config", "storage"],
 
     init: function init() {
-        this._localMarks = storage.newMap("local-marks", { store: true, privateData: true });
-        this._urlMarks = storage.newMap("url-marks", { store: false, privateData: true });
+        this._localMarks = storage.newMap("local-marks", { store: true });
+        this._urlMarks = storage.newMap("url-marks", { store: false });
 
         this._pendingJumps = [];
     },

--- a/common/content/quickmarks.js
+++ b/common/content/quickmarks.js
@@ -12,7 +12,7 @@ const QuickMarks = Module("quickmarks", {
     requires: ["config", "storage"],
 
     init: function () {
-        this._qmarks = storage.newMap("quickmarks", { store: true, privateData: true });
+        this._qmarks = storage.newMap("quickmarks", { store: true });
     },
 
     /**

--- a/common/content/sanitizer.js
+++ b/common/content/sanitizer.js
@@ -74,7 +74,7 @@ const Sanitizer = Module("sanitizer", {
         commands.add(["sa[nitize]"],
             "Clear private data",
             function (args) {
-                liberator.assert(!options['private'], "Cannot sanitize items in private mode");
+                liberator.assert(!liberator.isPrivateWindow(), "Cannot sanitize items in private mode");
 
                 let timespan = args["-timespan"] == undefined ? options["sanitizetimespan"] : args["-timespan"];
 

--- a/common/content/services.js
+++ b/common/content/services.js
@@ -42,10 +42,6 @@ const Services = Module("services", {
                 class_: "@mozilla.org/browser/nav-history-service;1",
                 iface:  [Ci.nsINavHistoryService, Ci.nsIBrowserHistory]
             },
-            "privateBrowsing": {
-                class_: "@mozilla.org/privatebrowsing;1",
-                iface:  Ci.nsIPrivateBrowsingService
-            },
             "profile": {
                 class_: "@mozilla.org/toolkit/profile-service;1",
                 iface:  Ci.nsIToolkitProfileService

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -641,23 +641,6 @@
 
 
 <item>
-    <tags>'noprivate' 'private'</tags>
-    <spec>'private'</spec>
-    <type>boolean</type>
-    <default>off</default>
-    <description>
-        <p>
-            Set the <str>private browsing</str> option. In private browsing mode
-            history, cache files, cookies, form data, passwords, download list
-            entries, local and URL marks, command-line history and macros are
-            available only for the duration of the private browsing session and
-            deleted when returning to normal browsing mode.
-        </p>
-    </description>
-</item>
-
-
-<item>
     <tags>'nohls' 'nohlsearch'</tags>
     <tags>'hls' 'hlsearch'</tags>
     <spec>'hlsearch' 'hls'</spec>

--- a/common/modules/storage.jsm
+++ b/common/modules/storage.jsm
@@ -151,8 +151,6 @@ function loadPref(name, store, type) {
 }
 
 function savePref(obj) {
-    if (obj.privateData)
-        return;
     if (obj.store && storage.infoPath)
         writeFile(getFile(obj.name), obj.serial);
 }

--- a/common/modules/storage.jsm
+++ b/common/modules/storage.jsm
@@ -151,7 +151,7 @@ function loadPref(name, store, type) {
 }
 
 function savePref(obj) {
-    if (obj.privateData && storage.privateMode)
+    if (obj.privateData)
         return;
     if (obj.store && storage.infoPath)
         writeFile(getFile(obj.name), obj.serial);
@@ -357,14 +357,6 @@ var storage = {
             savePref(obj);
     },
 
-    _privateMode: false,
-    get privateMode() this._privateMode,
-    set privateMode(val) {
-        if (!val && this._privateMode)
-            for (let key in keys)
-                this.load(key);
-        return this._privateMode = Boolean(val);
-    }
 };
 
 // vim: set fdm=marker sw=4 sts=4 et ft=javascript:

--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -6,6 +6,7 @@
     * Make <Ctrl-[> key always behave like <Esc> key (was missing from the command line handler)
     * Add support for :set hintmatching=fuzzy as a new, alternative way for hintmatching.
     * Don't display help message in command line for a normal click.
+    * Keep search history and command line history private in 'Private Browsing' mode.
 
 2014-11-09
     * Version 3.8.3


### PR DESCRIPTION
In non-private mode commands and searches are stored in global
'history-command' and 'history-search' stores respectively.

Since Firefox 20 the private browsing mode is on per window basis.

To support command and search history in per-window private mode:
* save command and search entries in a new
     - 'history-command-private' or
     - 'history-search-private'
      store.
* all opened private windows share these stores
* when the last private window is closed or Firefox itself is closed clear these two private stores.