### PR TITLE
ContentEditable elements are InputElements

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1125,7 +1125,8 @@ const Events = Module("events", {
         return ((elem instanceof HTMLInputElement && !/image/.test(elem.type)) ||
                  elem instanceof HTMLTextAreaElement ||
                  elem instanceof HTMLObjectElement ||
-                 elem instanceof HTMLEmbedElement);
+                 elem instanceof HTMLEmbedElement ||
+                 (elem && elem.contentEditable === "true"));
     }
 }, {
     commands: function () {


### PR DESCRIPTION
In onKeyUpOrDown, we check to see whether we should ignore a particular
key or not. One of the checks is whether an input element is focused.
'inInputElemFocused' checks whether the focused element is an instance
of Input or TextArea or Object or Embed. However, contentEditable divs
should be included in the check because some websites like facebook use
content editable elements instead of other input elements for better
styling.

Fixes #90.