### PR TITLE
Fix `set encoding=` functionality

### DIFF
--- a/common/content/browser.js
+++ b/common/content/browser.js
@@ -43,7 +43,7 @@ const Browser = Module("browser", {
                     // Stolen from browser.jar/content/browser/browser.js, more or less.
                     try {
                         config.browser.docShell.QueryInterface(Ci.nsIDocCharset).charset = val;
-                        if (PlacesUtils.history.setCharsetForURI !== undefined)
+                        if (PlacesUtils.history.setCharsetForURI)
                             PlacesUtils.history.setCharsetForURI(getWebNavigation().currentURI, val);
                         else
                             PlacesUtils.setCharsetForURI(getWebNavigation().currentURI, val);

--- a/common/content/browser.js
+++ b/common/content/browser.js
@@ -43,7 +43,10 @@ const Browser = Module("browser", {
                     // Stolen from browser.jar/content/browser/browser.js, more or less.
                     try {
                         config.browser.docShell.QueryInterface(Ci.nsIDocCharset).charset = val;
-                        PlacesUtils.history.setCharsetForURI(getWebNavigation().currentURI, val);
+                        if (PlacesUtils.history.setCharsetForURI !== undefined)
+                            PlacesUtils.history.setCharsetForURI(getWebNavigation().currentURI, val);
+                        else
+                            PlacesUtils.setCharsetForURI(getWebNavigation().currentURI, val);
                         getWebNavigation().reload(Ci.nsIWebNavigation.LOAD_FLAGS_CHARSET_CHANGE);
                     }
                     catch (e) { liberator.echoerr(e); }


### PR DESCRIPTION
Hi,

it seems `PlacesUtils.history.setCharsetForURI` has been replaced with `PlacesUtils.setCharsetForURI` ( see: https://bugzilla.mozilla.org/show_bug.cgi?id=880922#c18 ).
I couldn't use `set encoding=` for a while with the error `TypeError: PlacesUtils.history.setCharsetForURI is not a function` and confirmed this change fixed it.

I left the `PlacesUtils.history.setCharsetForURI` for people who uses older versions of Firefox (though I don't know when the change was made... :(