### PR TITLE
sanitize history: Remove ':open', ':tabopen' and ':winopen' command-line...

### DIFF
--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -1076,10 +1076,9 @@ const CommandLine = Module("commandline", {
             if (liberator.has("sanitizer") && (timespan || options["sanitizetimespan"]))
                 range = sanitizer.getClearRange(timespan || options["sanitizetimespan"]);
 
-            const self = this;
             this.store.mutate("filter", function (item) {
                 let timestamp = (item.timestamp || Date.now()/1000) * 1000;
-                return !line.privateData || timestamp < self.range[0] || timestamp > self.range[1];
+                return !item.privateData || timestamp < range[0] || timestamp > range[1];
             });
         },
         /**


### PR DESCRIPTION
According to the documentation (_:help 'sanitizeitems'_), when history items are sanitized with the `:sanitize history` command,  _:open_, _:tabopen_ and _:winopen_ command-line history entries should be also removed.

_CommandLine.History._**sanitize()** function is responsible for this but it fails with errors. Make that function work properly.