### PR TITLE
Dont redeclare or use let vars improperly

### DIFF
--- a/common/components/protocols.js
+++ b/common/components/protocols.js
@@ -251,9 +251,11 @@ Liberator.prototype = {
                 }
                 return fakeChannel(uri);
             }
+
+            let url;
             switch(uri.host) {
                 case "help":
-                    let url = this.FILE_MAP[uri.path.replace(/^\/|#.*/g, "")];
+                    url = this.FILE_MAP[uri.path.replace(/^\/|#.*/g, "")];
                     return makeChannel(url, uri);
                 case "help-overlay":
                     url = this.OVERLAY_MAP[uri.path.replace(/^\/|#.*/g, "")];


### PR DESCRIPTION
Fixes #139.

This is an issue because on line 258, we declare `url` with a `let`, but we also use `url` in 261, but we don't declare it there and if we use `let` there we get issues. So, I just moved the let out of the switch.