### PR TITLE
remove pasteClipboard function

### DIFF
--- a/common/content/editor.js
+++ b/common/content/editor.js
@@ -62,36 +62,6 @@ const Editor = Module("editor", {
         return text.substring(e.selectionStart, e.selectionEnd);
     },
 
-    pasteClipboard: function () {
-        if (liberator.has("Windows")) {
-            this.executeCommand("cmd_paste");
-            return;
-        }
-
-        // FIXME: #93 (<s-insert> in the bottom of a long textarea bounces up)
-        let elem = liberator.focus;
-
-        if (elem.setSelectionRange && util.readFromClipboard()) {
-            // readFromClipboard would return 'undefined' if not checked
-            // dunno about .setSelectionRange
-            // This is a hacky fix - but it works.
-            let curTop = elem.scrollTop;
-            let curLeft = elem.scrollLeft;
-
-            let rangeStart = elem.selectionStart; // caret position
-            let rangeEnd = elem.selectionEnd;
-            let tempStr1 = elem.value.substring(0, rangeStart);
-            let tempStr2 = util.readFromClipboard();
-            let tempStr3 = elem.value.substring(rangeEnd);
-            elem.value = tempStr1 + tempStr2 + tempStr3;
-            elem.selectionStart = rangeStart + tempStr2.length;
-            elem.selectionEnd = elem.selectionStart;
-
-            elem.scrollTop = curTop;
-            elem.scrollLeft = curLeft;
-        }
-    },
-
     // count is optional, defaults to 1
     executeCommand: function (cmd, count) {
         let controller = Editor.getController(cmd);
@@ -668,10 +638,6 @@ const Editor = Module("editor", {
         mappings.add(myModes,
             ["<C-End>"], "Move cursor to end of text field",
             function () { editor.executeCommand("cmd_moveBottom", 1); });*/
-
-        mappings.add(myModes,
-            ["<S-Insert>"], "Insert clipboard/selection",
-            function () { editor.pasteClipboard(); });
 
         mappings.add(modes.getCharModes("i"),
             ["<C-i>"], "Edit text field with an external editor",


### PR DESCRIPTION
This function is mapped to <S-Insert> and seems to mimic the default
behavior (pasting whatever is in the clipboard). However, it is also the
root of issue #166. I can't think of a reason why it should exist. It
might allow the use of <S-Insert> on Mac OS X, but I don't think
vimperator is the place for that. Also, there's cmd_paste already.