### PR TITLE
Implement yank anchor URL hint mode.

### DIFF
--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -35,6 +35,7 @@ const Hints = Module("hints", {
         Mode.defaultValue("tags", function () function () options.hinttags);
         function extended() options.extendedhinttags;
         function images() "//*[@src]";
+        function anchors() "//*[@id or @name]";
 
         this._hintModes = {
             ";": Mode("Focus hint",                         function (elem) buffer.focusElement(elem),                             extended),
@@ -56,6 +57,11 @@ const Hints = Module("hints", {
             V: Mode("View hint source in external editor",  function (elem, loc) buffer.viewSource(loc, true),                     extended),
             y: Mode("Yank hint location",                   function (elem, loc) util.copyToClipboard(loc, true)),
             Y: Mode("Yank hint description",                function (elem) util.copyToClipboard(elem.textContent || "", true),    extended),
+            "#": Mode("Yank hint anchor URL",               function (elem) {
+                let uri = elem.ownerDocument.documentURIObject.clone();
+                uri.ref = elem.id || elem.name;
+                util.copyToClipboard(uri.spec, true);
+            }, anchors),
             c: Mode("Open context menu",                    function (elem) buffer.openContextMenu(elem),                          extended),
             i: Mode("Show media object",                    function (elem) liberator.open(elem.src),                              images),
             I: Mode("Show media object in a new tab",       function (elem) liberator.open(elem.src, liberator.NEW_TAB),           images),

--- a/common/locale/en-US/hints.xml
+++ b/common/locale/en-US/hints.xml
@@ -90,6 +90,7 @@ tedious unless you always visit the first link on a page.
             <li><tag>;V</tag> <em>V</em> to view its destination source in the external editor</li>
             <li><tag>;y</tag> <em>y</em> to yank its destination location</li>
             <li><tag>;Y</tag> <em>Y</em> to yank its text description</li>
+            <li><tag>;#</tag> <em>n</em> to yank its anchor URL</li>
             <li><tag>;c</tag> <em>c</em> to open its context menu</li>
             <li><tag>;i</tag> <em>i</em> to open a media object</li>
             <li><tag>;I</tag> <em>I</em> to open a media object in a new tab</li>

--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -1,3 +1,8 @@
+201x-xx-xx:
+    * Add ';#', an extended hint mode for yanking the anchor URL of an element
+      (the URL of the page with the fragment set to the element's 'id' or
+      'name' attribute)
+
 2015-02-15: Missed Valentine's day
     * Version 3.9
     * We don't override <S-Insert> in textboxes anymore, so it does the default


### PR DESCRIPTION
Implement an extended hint mode for yanking anchor URLs of appropriate elements (namely, those that have either an id or name attribute). This is useful for pointing people to a specific part of the page, for instance sections of a Wikipedia article. I chose ;n (aNchor) because ;a and ;A were already taken.