### PR TITLE
fix selectMessage for unify folders

### DIFF
--- a/muttator/content/mail.js
+++ b/muttator/content/mail.js
@@ -366,7 +366,8 @@ const Mail = Module("mail", {
                     reverse ? (i >= 0) : (i < gDBView.rowCount);
                     reverse ? i-- : i++) {
                 let key = gDBView.getKeyAt(i);
-                let msg = gDBView.db.GetMsgHdrForKey(key);
+                let folder = gDBView.getFolderForViewIndex(i); 
+                let msg = folder.msgDatabase.GetMsgHdrForKey(key);
 
                 // a closed thread
                 if (openThreads && closedThread(i)) {


### PR DESCRIPTION
Hi,

A manifestation of this problem is the following: suppose you have two accounts configured, and you selected "unified folders view" (view menu/folders/unified), then for example, you will have a unified inbox root folder, and then two inbox childs folders. Now, if you are in the unified folder, thinks like j/k will not work.

This simple fix just retrieves the folder of the row and uses its db.