### PR TITLE
Move cursor to the end of input elements on focus.

### DIFF
--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -515,6 +515,13 @@ const Buffer = Module("buffer", {
         else {
             elem.focus();
 
+            // put the cursor at the end of the content inside an input element
+            // when focused (unless a part of it was selected previously)
+            if ((elem instanceof HTMLInputElement || elem instanceof HTMLTextAreaElement) &&
+                elem.value && elem.selectionStart !== undefined &&
+                elem.selectionStart === elem.selectionEnd)
+                elem.selectionStart = elem.selectionEnd = elem.value.length;
+
             // for imagemap
             if (elem instanceof HTMLAreaElement) {
                 let doc = config.browser.contentDocument;


### PR DESCRIPTION
Currently, when an input element is focused (e.g. via 'gi'), the cursor is placed at the beginning even if there is already some text inside the element. Probably the most common thing you want to do in such a situation is to enter more text or edit some suffix of the preexisting text so it's useful if the cursor is already at the right position when you focus the element.

Consider the supplied patch a draft version since I'm not too sure all of the checks I've made are needed nor if these are *all* the checks that might be needed (e.g. should we check for contentEditable also?).