### PR TITLE
Dispatches an input event when editing externally

### DIFF
--- a/common/content/editor.js
+++ b/common/content/editor.js
@@ -337,8 +337,10 @@ const Editor = Module("editor", {
                     lastUpdate = Date.now();
 
                     let val = tmpfile.read();
-                    if (textBox)
+                    if (textBox) {
                         textBox.value = val;
+                        textBox.dispatchEvent(new InputEvent('input'));
+                    }
                     else if (nsEditor) {
                         let wholeDocRange = nsEditor.document.createRange();
                         let rootNode = nsEditor.rootElement.QueryInterface(Ci.nsIDOMNode);


### PR DESCRIPTION
When you edit a text area externally and the editor ends and the text area is updated it never triggers an 'input' event. That is because it is set via `textBox.value = val` instead of user input.

Many sites/apps rely on the 'input' event being triggered to manage their internal store. Notably [TiddlyWiki][1] and [StackOverflow][2]. This forced the user to then further manipulate the content after editing to force the browser to dispatch these events. 

Adding a programmatic 'input' event will prevent this extra user interaction (which with could potentially cause a lose of data in some apps) and trigger JavaScript event handlers appropriately.

[1]: http://tiddlywiki.com/
[2]: http://stackoverflow.com/