### PR TITLE
Make muttator work with Thunderbird 36

### DIFF
--- a/muttator/content/mail.js
+++ b/muttator/content/mail.js
@@ -187,8 +187,7 @@ const Mail = Module("mail", {
 
         params.type = Ci.nsIMsgCompType.New;
 
-        const msgComposeService = Cc["@mozilla.org/messengercompose;1"].getService();
-        msgComposeService = msgComposeService.QueryInterface(Ci.nsIMsgComposeService);
+        const msgComposeService = Cc["@mozilla.org/messengercompose;1"].getService().QueryInterface(Ci.nsIMsgComposeService);
         msgComposeService.OpenComposeWindowWithParams(null, params);
     },
 


### PR DESCRIPTION
This was causing muttator not to work with Thunderbird 36 anymore. Can anyone confirm that this actually fixes the problem #187?