### PR TITLE
fixed covered .liberator-floatbox

### DIFF
--- a/common/skin/liberator.css
+++ b/common/skin/liberator.css
@@ -72,6 +72,7 @@
     position: fixed;
     width: 100%;
     height: 100%;
+    z-index: 1000;
 }
 
 .liberator-container.animation[collapsed='true'] {


### PR DESCRIPTION
Tree Style Tab coveres the floatbox, so you cannot see URL suggestions.