### PR TITLE
Better choice of identitty when composing mail

### DIFF
--- a/muttator/content/mail.js
+++ b/muttator/content/mail.js
@@ -155,6 +155,16 @@ const Mail = Module("mail", {
         let params = Cc["@mozilla.org/messengercompose/composeparams;1"].createInstance(Ci.nsIMsgComposeParams);
         params.composeFields = Cc["@mozilla.org/messengercompose/composefields;1"].createInstance(Ci.nsIMsgCompFields);
 
+        let identity = window.accoutManager.defaultAccount.defaultIdentity;
+        let selectedFolder = window.gFolderTreeView.getSelectedFolders()[0];
+        if (selectedFolder) {
+            if (selectedFolder.customIdentity)
+                identity = selectedFolder.customIdentity;
+            else if (window.getIdentityForServer(selectedFolder.server))
+                identity = window.getIdentityForServer(selectedFolder.server);
+        }
+        params.identity = identity;
+
         if (args) {
             if (args.originalMsg)
                 params.originalMsgURI = args.originalMsg;

--- a/muttator/content/mail.js
+++ b/muttator/content/mail.js
@@ -155,7 +155,7 @@ const Mail = Module("mail", {
         let params = Cc["@mozilla.org/messengercompose/composeparams;1"].createInstance(Ci.nsIMsgComposeParams);
         params.composeFields = Cc["@mozilla.org/messengercompose/composefields;1"].createInstance(Ci.nsIMsgCompFields);
 
-        let identity = window.accoutManager.defaultAccount.defaultIdentity;
+        let identity = window.accountManager.defaultAccount.defaultIdentity;
         let selectedFolder = window.gFolderTreeView.getSelectedFolders()[0];
         if (selectedFolder) {
             if (selectedFolder.customIdentity)


### PR DESCRIPTION
When composing a mail in Thunderbird, by default, the default identity of the folder/account you're currently viewing is used. When using Muttator, no identity is set, and the default identity is used, which is not always convenient if you're using multiple accounts/identities.

I changed this to use the default identity of the current folder or account, like the default behaviour of Thunderbird.