### PR TITLE
Stop propagation for keyboard event if that key are contained in -except option on :ignorekeys

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1098,12 +1098,22 @@ const Events = Module("events", {
 
     onKeyUpOrDown: function (event) {
         // Always let the event be handled by the webpage/Firefox for certain modes
-        if (modes.passNextKey || modes.passAllKeys || modes.isMenuShown || Events.isInputElemFocused())
+        if (modes.passNextKey || modes.isMenuShown || Events.isInputElemFocused())
             return;
+
+        let key = events.toString(event);
+        if (modes.passAllKeys) {
+            // Respect "unignored" keys
+            if (modes._passKeysExceptions == null || modes._passKeysExceptions.indexOf(key) < 0) {
+                return;
+            } else {
+                event.stopPropagation();
+                return;
+            }
+        }
 
         // Many sites perform (useful) actions on keydown.
         // Let's keep the most common ones unless we have a mapping for that
-        let key = events.toString(event);
         if (event.type == "keydown" && this.isEscapeKey(key)) {
             this.onEscape(); // We do our Escape handling here, as the on "onKeyPress" may not always work if websites override the keydown event
             event.stopPropagation();

--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -1,4 +1,5 @@
 201x-xx-xx:
+    * Stop propagation for keyboard event if that key are contained in -except option on :ignorekeys
 
 2015-08-25:
     * Version 3.10.1


### PR DESCRIPTION
`-except` option in ignorekeys are support in `onKeyPress`, but does not support in `onKeyUpOrDown`.

Reproduce methods
---------
1. `:nmap l <C-n>`
2. `:ignorekeys add -except l,<C-n> github.com`
3. Open https://github.com/vimperator/vimperator-labs
4. Press `l`. worked correctly
5. Open https://github.com/vimperator/vimperator-labs/blob/master/.gitignore
6. Press `l`. popup jump window in github and doesn't worked correctly
