### PR TITLE
Fix Esc key not escaping input fields

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1128,7 +1128,7 @@ const Events = Module("events", {
         }
         
         if (liberator.mode == modes.INSERT || liberator.mode == modes.TEXTAREA) {
-            event.stropPropagation();
+            event.stopPropagation();
             return;
         }
 

--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1110,6 +1110,10 @@ const Events = Module("events", {
             return;
         }
 
+        if (liberator.mode == modes.INSERT || liberator.mode == modes.TEXTAREA) {
+            return;
+        }
+
         let url = typeof(buffer) != "undefined" ? buffer.URL : "";
         let inputStr = this._input.buffer + key;
         let countStr = inputStr.match(/^[1-9][0-9]*|/)[0];
@@ -1123,11 +1127,6 @@ const Events = Module("events", {
         // Or we have a mapping starting with that key
         let candidates = mappings.getCandidates(liberator.mode, candidateCommand, url);
         if (candidates.length > 0) { // We want to handle that key ourselves
-            event.stopPropagation();
-            return;
-        }
-        
-        if (liberator.mode == modes.INSERT || liberator.mode == modes.TEXTAREA) {
             event.stopPropagation();
             return;
         }

--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1098,7 +1098,7 @@ const Events = Module("events", {
 
     onKeyUpOrDown: function (event) {
         // Always let the event be handled by the webpage/Firefox for certain modes
-        if (modes.passNextKey || modes.passAllKeys || modes.isMenuShown || Events.isInputElemFocused())
+        if (modes.passNextKey || modes.passAllKeys || modes.isMenuShown) 
             return;
 
         // Many sites perform (useful) actions on keydown.
@@ -1124,6 +1124,11 @@ const Events = Module("events", {
         let candidates = mappings.getCandidates(liberator.mode, candidateCommand, url);
         if (candidates.length > 0) { // We want to handle that key ourselves
             event.stopPropagation();
+            return;
+        }
+        
+        if (liberator.mode == modes.INSERT || liberator.mode == modes.TEXTAREA) {
+            event.stropPropagation();
             return;
         }
 


### PR DESCRIPTION
Fixes #46, and does not break content editable divs (from my testing, content editable divs don't work in FF40+ and in FF39, content editable divs actually didn't escape properly when pressing Escape without this change)
