### PR TITLE
Fix Esc in Ignore mode

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1098,7 +1098,7 @@ const Events = Module("events", {
 
     onKeyUpOrDown: function (event) {
         // Always let the event be handled by the webpage/Firefox for certain modes
-        if (modes.passNextKey || modes.isMenuShown) 
+        if (modes.isMenuShown) 
             return;
 
         let key = events.toString(event);
@@ -1115,6 +1115,11 @@ const Events = Module("events", {
         // Many sites perform (useful) actions on keydown.
         // Let's keep the most common ones unless we have a mapping for that
         if (event.type == "keydown" && this.isEscapeKey(key)) {
+            if (modes.passNextKey) {
+                modes.passNextKey = false;
+                return;
+            }
+
             this.onEscape(); // We do our Escape handling here, as the on "onKeyPress" may not always work if websites override the keydown event
             event.stopPropagation();
             return;


### PR DESCRIPTION
Pressing Escape in Ignore (next) mode is passed to the webpage, but doesn't leave Ignore mode.