### PR TITLE
Add option for controlling passthrough to webpages

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1141,6 +1141,9 @@ const Events = Module("events", {
             return;
         }
 
+        if (!options['passthrough'])
+            event.stopPropagation();
+
         // liberator.echo ("key: " + key + "\nkeycode: " + event.keyCode + "\nchar: " + event.charCode + "\ntype: " + event.type + "\nwhich: " + event.which);
     },
 

--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -1129,6 +1129,10 @@ const Tabs = Module("tabs", {
                     ]
                 });
 
+            options.add(["passthrough"],
+                "Define if keypresses are passed to webpages outside of Insert mode",
+                "boolean", false);
+
             options.add(["popups", "pps"],
                 "Where to show requested popup windows",
                 "stringlist", "tab",

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -894,6 +894,17 @@
 
 
 <item>
+    <tags>'nopassthrough' 'passthrough'</tags>
+    <spec>'passthrough'</spec>
+    <type>boolean</type>
+    <default>off</default>
+    <description>
+        <p>Define if keypresses are passed to webpages if you are not in Insert mode.</p>
+    </description>
+</item>
+
+
+<item>
     <tags>'pps' 'popups'</tags>
     <spec>'popups' 'pps'</spec>
     <type>stringlist</type>

--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -5,6 +5,9 @@
     browser.tabs.closeWindowWithLastTab, which means those who are used to :tabclose never closing
     the window when closing the last tab, should set this option to false (either through about:config
     or with :set! browser.tabs.closeWindowWithLastTab=false)
+    * Added setting for controlling if keypresses are passed to webpages when
+    outside of Insert/Passthrough modes (to revert to old setting,
+    :set passthrough=true)
 
 2015-08-25:
     * Version 3.10.1


### PR DESCRIPTION
Allows you to stop keypresses being passed to webpages when you are outside of Insert/Passthrough modes. Fixes #286.