### PR TITLE
Avoid tab spawn bomb

### DIFF
--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -717,7 +717,7 @@ const Tabs = Module("tabs", {
         commands.add(["tabd[o]", "bufd[o]"],
             "Execute a command in each tab",
             function (args) {
-		let count = tabs.count;
+                let count = tabs.count;
                 for (let i = 0; i < Math.min(tabs.count, count); i++) {
                     tabs.select(i);
                     liberator.execute(args.string, null, true);

--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -717,7 +717,8 @@ const Tabs = Module("tabs", {
         commands.add(["tabd[o]", "bufd[o]"],
             "Execute a command in each tab",
             function (args) {
-                for (let i = 0; i < tabs.count; i++) {
+		let count = tabs.count;
+                for (let i = 0; i < Math.min(tabs.count, count); i++) {
                     tabs.select(i);
                     liberator.execute(args.string, null, true);
                 }


### PR DESCRIPTION
Currently it is possible to execute a tab spawn bomb by the simple command(if at least one tab exists):
```
:tabdo tabduplicate
```

This pull request avoids this.