### PR TITLE
changed z-index to max allowed by firefox

### DIFF
--- a/common/skin/liberator.css
+++ b/common/skin/liberator.css
@@ -2,7 +2,7 @@
 
 [liberator|highlight~=HintImage],
 [liberator|highlight~=Hint] {
-    z-index: 5000;
+    z-index: 2147483647;
     position: absolute !important;
 }
 [liberator|highlight~=Search] {


### PR DESCRIPTION
A z-index of 5000 is not enough for some sites.  For example, the menubar at wikia.com sets the z-index to something around 5 million, which obscures the hints.

I verified that `2147483647 = 2^31-1`  is the maximum z-index supported by Firefox. See https://github.com/vimperator/vimperator-labs/issues/255
