### PR TITLE
Fix statusline ssl icon is not working

### DIFF
--- a/common/content/statusline.js
+++ b/common/content/statusline.js
@@ -214,32 +214,48 @@ const StatusLine = Module("statusline", {
             });
         statusline.addField("ssl", "The currently SSL status", "liberator-status-ssl",
             function updateSSLState (node, state) {
-                var className = "";
+                var className = "notSecure";
+                var tooltip = gNavigatorBundle.getString("identity.unknown.tooltip");
                 if (!state) {
                     let securityUI = config.tabbrowser.securityUI;
                     if (securityUI)
                         state = securityUI.state || 0;
                 }
                 const WPL = Components.interfaces.nsIWebProgressListener;
-                if (state & WPL.STATE_IDENTITY_EV_TOPLEVEL)
+                if (state & WPL.STATE_IDENTITY_EV_TOPLEVEL) {
                     className = "verifiedIdentity";
-                else if (state & WPL.STATE_IS_SECURE)
+                    if (state & WPL.STATE_BLOCKED_MIXED_ACTIVE_CONTENT)
+                        className = "mixedActiveBlocked";
+                    tooltip = gNavigatorBundle.getFormattedString(
+                        "identity.identified.verifier",
+                        [gIdentityHandler.getIdentityData().caOrg]);
+                } else if (state & WPL.STATE_IS_SECURE) {
                     className = "verifiedDomain";
-                else if (state & WPL.STATE_IS_BROKEN) {
-                    if ((state & WPL.STATE_LOADED_MIXED_ACTIVE_CONTENT) &&
-                        options.getPref("security.mixed_content.block_active_content", false))
+                    if (state & WPL.STATE_BLOCKED_MIXED_ACTIVE_CONTENT)
+                        className = "mixedActiveBlocked";
+                    tooltip = gNavigatorBundle.getFormattedString(
+                        "identity.identified.verifier",
+                        [gIdentityHandler.getIdentityData().caOrg]);
+                } else if (state & WPL.STATE_IS_BROKEN) {
+                    if (state & WPL.STATE_LOADED_MIXED_ACTIVE_CONTENT)
                         className = "mixedActiveContent";
+                    else
+                        className = "mixedDisplayContent";
+                    tooltip = gNavigatorBundle.getString("identity.unknown.tooltip");
                 }
-
                 node.className = className;
+                node.setAttribute("tooltiptext", tooltip);
             }, {
                 openPopup: function (anchor) {
                     var handler = window.gIdentityHandler;
                     if (typeof handler === "undefiend") // Thunderbird has none
                         return;
 
+                    if (handler.refreshIdentityPopup)
+                        handler.refreshIdentityPopup();
+                    else
+                        handler.setPopupMessages(handler._identityBox.className);
                     handler._identityPopup.hidden = false;
-                    handler.setPopupMessages(handler._identityBox.className);
                     handler._identityPopup.openPopup(anchor);
                 },
             });

--- a/common/skin/liberator.css
+++ b/common/skin/liberator.css
@@ -155,6 +155,18 @@
         visibility: visible;
         list-style-image: url(chrome://browser/skin/identity-mixed-active-loaded.svg);
     }
+    #liberator-status-ssl.mixedDisplayContent {
+        visibility: visible;
+        list-style-image: url(chrome://browser/skin/identity-mixed-passive-loaded.svg);
+    }
+    #liberator-status-ssl.mixedActiveBlocked {
+        visibility: visible;
+        list-style-image: url(chrome://browser/skin/identity-mixed-active-blocked.svg);
+    }
+    #liberator-status-ssl.notSecure {
+        visibility: visible;
+        list-style-image: url(chrome://browser/skin/identity-not-secure.svg);
+    }
 
     #liberator-commandline-prompt {
         background-color: inherit;


### PR DESCRIPTION
From Firefox 42, gIdentityHandler methods are changed. So ssl popup was
not working. Fixed this for Firefox 42 and higher, and added more icons
for ssl states and tooltip.