### PR TITLE
Suggestengines only using visible search engines

### DIFF
--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -1617,7 +1617,7 @@ const CommandLine = Module("commandline", {
              "stringlist", "google",
              {
                  completer: function completer(value) {
-                     let engines = services.get("search").getEngines({})
+                     let engines = services.get("search").getVisibleEngines({})
                                            .filter(function (engine) engine.supportsResponseType("application/x-suggestions+json"));
 
                      return engines.map(function (engine) [engine.alias, engine.description]);


### PR DESCRIPTION

    * Non-visible, or deleted search engines are not exposed
    in the UI, and as far as the user is concerned they do
    not exist.
    * The default search engines (or other deleted ones) may
    still be stored (search.json etc).
    * With this in mind, suggestengines should respect the
    ability to delete (hide) engines, and only show/use
    visible search engines.

While minor. it does add some confusion when working with `suggestengines`. Especially so, if one or more of your search engines does not include support for search suggestions. It can be difficult to tell if the search engines are stored in multiple places, out of sync or whatever. 