### PR TITLE
Explain QuickMark groups using urlseparator

### DIFF
--- a/common/locale/en-US/marks.xml
+++ b/common/locale/en-US/marks.xml
@@ -301,6 +301,10 @@
         <p>
              <ex>:qmark f http://forum1.com, http://forum2.com, imdb some artist</ex>
         </p>
+
+        <p>
+            <o>urlseparator</o> defines the delimiter between the URLs (default: ", ")
+        </p>
     </description>
 </item>
 

--- a/common/locale/ja/marks.xml
+++ b/common/locale/ja/marks.xml
@@ -285,6 +285,10 @@
         <p>
              <ex>:qmark f http://forum1.com, http://forum2.com, imdb some artist</ex>
         </p>
+
+        <p>
+            <o>urlseparator</o> は URL 間の区切り文字を指定する（デフォルト: ", "）
+        </p>
     </description>
 </item>
 


### PR DESCRIPTION
 
    * The separator used in documentation is "hardcoded", as such
    it can be a bit confusing when it does not work with ", "
    in the event the urlseparator option is changed.
    * One example: #362

 