### PR TITLE
added :panorama rename subcommand

### DIFF
--- a/vimperator/content/tabgroup.js
+++ b/vimperator/content/tabgroup.js
@@ -348,6 +348,35 @@ const TabGroup = Module("tabGroup", {
                     completer: function (context) completion.tabgroup(context, false),
                 }),
             /**
+             * Panorama SubCommand rename
+             * rename {name}.
+             * clear the name of the current group if bang(!) specified and {name} is ommited.
+             */
+            new Command(["rename", "mv"], "Rename current tab group (or reset to '(Untitled)').",
+                function (args) {
+                    let title = args.literalArg;
+                    if (!title) {
+                        if (args.bang)
+                            title = "";
+                        else {
+                            liberator.echoerr("No title supplied!  Add \"!\" if want to clear it.");
+                            return;
+                        }
+                    }
+                    let activeGroup = tabGroup.tabView.GroupItems.getActiveGroupItem();
+                    if (activeGroup)
+                        activeGroup.setTitle(title);
+                }, {
+                    bang: true,
+                    literal: 0,
+                    completer: function (context) {
+                        context.title = ["Rename current group"];
+                        let activeGroup = tabGroup.tabView.GroupItems.getActiveGroupItem();
+                        let title = activeGroup ? activeGroup.getTitle() : "";
+                        context.completions = title ? [[title, ""]] : [];
+                    }
+                }),
+            /**
              * Panorama SubCommand switch
              * switch to the {group}.
              * switch to {count}th next group if {count} specified.

--- a/vimperator/locale/en-US/tabs.xml
+++ b/vimperator/locale/en-US/tabs.xml
@@ -124,6 +124,21 @@
         </item>
 
         <item>
+            <tags>tabgroups-rename tabgroups-mv</tags>
+            <spec>rename<oa>!</oa> <oa>newGroupName</oa></spec>
+            <spec>mv<oa>!</oa> <oa>newGroupName</oa></spec>
+            <description>
+                <p>
+                    Rename current tab group to <oa>newGroupName</oa>.
+                </p>
+                <p>
+                    If <oa>newGroupName</oa> is not supplied and <oa>!</oa> is
+                    specified, resets group's name to <o>(Untitled)</o>.
+                </p>
+            </description>
+        </item>
+
+        <item>
             <tags>tabgroups-switch</tags>
             <spec><oa>count</oa>switch <a>groupName</a></spec>
             <description>


### PR DESCRIPTION
since i've discovered `:panorama` command, i can't stop using it all the time.  this PL brings missing rename feature.

here some cool remappings from my .vimparatorrc:
```viml
" firefox panorama (groups of tabs)
noremap <M-e> :panorama<Space>
inoremap <M-e> <Esc>:panorama<Space>
noremap <Silent> <M-S-e> :panorama<Space>switch<Space>
inoremap <Silent> <M-S-e> <Esc>:panorama<Space>switch<Space>
```
maybe it would be good idea to add them by default.  note that with `<M-S-e>` remapped, it's still possible to bring firefox's native panorama using `'IGNORE'` mode (pressing `i`).