### PR TITLE
Compatibility with Tab Groups add-on

### DIFF
--- a/vimperator/content/tabgroup.js
+++ b/vimperator/content/tabgroup.js
@@ -11,13 +11,13 @@
 /**
  * @instance tabgroup
  */
-const TabGroup = Module("tabGroup", {
+var TabGroup = Module("tabGroup", {
     requires: ["config", "tabs"],
 
-    TV: window.TabView,
+    get TV () { return window.TabView; },
 
     get tabView () {
-        const TV = window.TabView;
+        let TV = this.TV;
         if (!TV)
             return null;
         if (!TV._window || !TV._window.GroupItems) {
@@ -26,8 +26,7 @@ const TabGroup = Module("tabGroup", {
             while (waiting)
                 liberator.threadYield(false, true);
         }
-        delete this.tabView;
-        return this.tabView = TV._window;
+        return TV._window;
     },
 
     get appTabs () {


### PR DESCRIPTION
Currently, Vimperator checks for the existence of TabView when first run. My Tab Groups add-on reimplements the tab groups functionality that will be removed in Firefox 45. However it is a restartless add-on, so its functionality can be enabled and disabled immediately without restarting the browser.

In addition, the add-on also makes it possible to (de)initialize just the tabView frame on demand as well (mostly for compatibility with other add-ons).

This pull request addresses both issues. Note that it does not make any sort of pretty print saying "Oops, you've tried to run a panorama command when no panorama exists.". If the add-on and the native Firefox panorama don't exist it will just fail, which is expected anyway.

Note that this still won't work correctly with the currently released version of Tab Groups (1.0.1), it requires a build with https://github.com/Quicksaver/Tab-Groups/commit/40ab03aa168c0c6efcc9a7ebfd5940543a8a164d which isn't released yet; that will probably happen later this week or early next week.