### PR TITLE
Expose Command constructor

### DIFF
--- a/common/content/commands.js
+++ b/common/content/commands.js
@@ -1187,6 +1187,8 @@ const Commands = Module("commands", {
 });
 
 (function () {
+    /* Expose Command constructor for user-defined sub-commands. */
+    Object.defineProperty(this, "Command", { value: Command });
 
     Commands.quoteMap = {
         "\n": "n",


### PR DESCRIPTION
The semantics of `const` has been changed in Firefox 44.
https://blog.mozilla.org/addons/2015/10/14/breaking-changes-let-const-firefox-nightly-44/
This patch allows user-defined sub-commands in Firefix 44+.

```js
commands.addUserCommand(['mycommand'], 'My command', function() {}, {
  subCommands: [
    new commands.Command(['sub'], 'My sub-command', function() { doSomething(); }),
  ],
});
```