### PR TITLE
Fix #394: ContentSeparator lost after hiding statusbar

### DIFF
--- a/common/content/statusline.js
+++ b/common/content/statusline.js
@@ -148,13 +148,14 @@ const StatusLine = Module("statusline", {
         var toggle_off = function () {
             bb.style.height = '0px';
             bb.style.overflow = 'hidden';
+            sv.contentSeparator = highlight.get('ContentSeparator').value;
             highlight.set('ContentSeparator', 'display: none;');
         };
 
         var toggle_on = function () {
             bb.style.height = '';
             bb.style.overflow = '';
-            highlight.set('ContentSeparator', sv.contentSeparatorValue);
+            highlight.set('ContentSeparator', sv.contentSeparator);
         };
 
         switch (request) {


### PR DESCRIPTION
Value of ContentSeparator might change during runtime and it was loaded
from an undefined variable.