### PR TITLE
No need to set contentSeparator variable

### DIFF
--- a/common/content/statusline.js
+++ b/common/content/statusline.js
@@ -148,7 +148,6 @@ const StatusLine = Module("statusline", {
         var toggle_off = function () {
             bb.style.height = '0px';
             bb.style.overflow = 'hidden';
-            sv.contentSeparator = highlight.get('ContentSeparator').value;
             highlight.set('ContentSeparator', 'display: none;');
         };
 


### PR DESCRIPTION
setVisibility.contentSeparator is already set.
And setting contentSeparator in toggle_off() makes trouble in manual toggle on/off.