### PR TITLE
Fix some validator warnings

### DIFF
--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -671,7 +671,6 @@ const Buffer = Module("buffer", {
      * @param {Node} elem The context element.
      */
     openContextMenu: function (elem) {
-        document.popupNode = elem;
         let menu = document.getElementById("contentAreaContextMenu");
         menu.showPopup(elem, -1, -1, "context", "bottomleft", "topleft");
     },

--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -1762,7 +1762,7 @@ const ItemList = Class("ItemList", {
             this._divNodes.completions.appendChild(context.cache.nodes.root);
         }, this);
 
-        setTimeout(this.closure._autoSize, 0);
+        this.setTimeout(this.closure._autoSize, 0);
     },
 
     /**

--- a/common/content/commands.js
+++ b/common/content/commands.js
@@ -892,7 +892,7 @@ const Commands = Module("commands", {
                 if ((res = str.match(/^()((?:[^\\\s"']|\\.)+)((?:\\$)?)/)))
                     arg += res[2].replace(/\\(.)/g, "$1");
                 else if ((res = str.match(/^(")((?:[^\\"]|\\.)*)("?)/)))
-                    arg += eval(res[0] + (res[3] ? "" : '"'));
+                    arg += JSON.parse(res[0] + (res[3] ? "" : '"'));
                 else if ((res = str.match(/^(')((?:[^\\']|\\.)*)('?)/)))
                     arg += res[2].replace(/\\(.)/g, function (n0, n1) /[\\']/.test(n1) ? n1 : n0);
                 break;
@@ -901,7 +901,7 @@ const Commands = Module("commands", {
                 if ((res = str.match(/^()((?:[^\\\s"']|\\.)+)((?:\\$)?)/)))
                     arg += res[2].replace(/\\(.)/g, "$1");
                 else if ((res = str.match(/^(")((?:[^\\"]|\\.)*)("?)/)))
-                    arg += eval(res[0] + (res[3] ? "" : '"'));
+                    arg += JSON.parse(res[0] + (res[3] ? "" : '"'));
                 else if ((res = str.match(/^(')((?:[^']|'')*)('?)/)))
                     arg += res[2].replace("''", "'", "g");
                 break;
@@ -912,7 +912,7 @@ const Commands = Module("commands", {
                 else if ((res = str.match(/^(""")((?:.?.?[^"])*)((?:""")?)/)))
                     arg += res[2];
                 else if ((res = str.match(/^(")((?:[^\\"]|\\.)*)("?)/)))
-                    arg += eval(res[0] + (res[3] ? "" : '"'));
+                    arg += JSON.parse(res[0] + (res[3] ? "" : '"'));
                 else if ((res = str.match(/^(')((?:[^\\']|\\.)*)('?)/)))
                     arg += res[2].replace(/\\(.)/g, function (n0, n1) /[\\']/.test(n1) ? n1 : n0);
                 break;


### PR DESCRIPTION
This fixes some of AMO's validator's warnings. A bunch we probably can't do anything about easily because they're inherently how the class system is made and how autocommands are made while others are just the validator being silly because it sees "mouseover" and thinks we're listening to it and not handling it correctly.