### PR TITLE
Fix #280 CSS transparent is not working on MOW

### DIFF
--- a/common/skin/liberator.css
+++ b/common/skin/liberator.css
@@ -198,7 +198,6 @@
     #liberator-multiline-output,
     #liberator-multiline-input {
         overflow: hidden;
-        background-color: white;
         color: black;
     }
 


### PR DESCRIPTION
`Normal` highlight should control background color of MOW, so I removed implemented background-color of MOW.