### PR TITLE
Fix #394: Use modes instead of states

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1182,7 +1182,7 @@ const Events = Module("events", {
             this._fullscreen = window.fullScreen;
             liberator.triggerObserver("fullscreen", this._fullscreen);
             autocommands.trigger("Fullscreen", { state: this._fullscreen });
-            statusline.setVisibility(statusline.setVisibility.EVENT_FULLSCREEN);
+            statusline.setVisibility(statusline.setVisibility.UPDATE);
         }
     }
 }, {

--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1182,7 +1182,7 @@ const Events = Module("events", {
             this._fullscreen = window.fullScreen;
             liberator.triggerObserver("fullscreen", this._fullscreen);
             autocommands.trigger("Fullscreen", { state: this._fullscreen });
-            statusline.setVisibility(statusline.setVisibility.FULLSCREEN);
+            statusline.setVisibility(statusline.setVisibility.EVENT_FULLSCREEN);
         }
     }
 }, {

--- a/common/content/modes.js
+++ b/common/content/modes.js
@@ -104,7 +104,7 @@ const Modes = Module("modes", {
                 if (oldExtended & modes.HINTS)
                     hints.hide();
                 commandline.close();
-                statusline.setVisibility(statusline.setVisibility.MODE_OFF);
+                statusline.setVisibility(statusline.setVisibility.EVENT_HIDE);
                 break;
         }
 
@@ -122,7 +122,7 @@ const Modes = Module("modes", {
         }
 
         if (newMode == modes.COMMAND_LINE) {
-            statusline.setVisibility(statusline.setVisibility.MODE_ON);
+            statusline.setVisibility(statusline.setVisibility.EVENT_SHOW);
         }
 
     },

--- a/common/content/modes.js
+++ b/common/content/modes.js
@@ -104,7 +104,7 @@ const Modes = Module("modes", {
                 if (oldExtended & modes.HINTS)
                     hints.hide();
                 commandline.close();
-                statusline.setVisibility(statusline.setVisibility.EVENT_HIDE);
+                statusline.setVisibility(statusline.setVisibility.HIDE);
                 break;
         }
 
@@ -122,7 +122,7 @@ const Modes = Module("modes", {
         }
 
         if (newMode == modes.COMMAND_LINE) {
-            statusline.setVisibility(statusline.setVisibility.EVENT_SHOW);
+            statusline.setVisibility(statusline.setVisibility.SHOW);
         }
 
     },

--- a/common/content/statusline.js
+++ b/common/content/statusline.js
@@ -131,6 +131,7 @@ const StatusLine = Module("statusline", {
             this.setVisibility.UPDATE = 0; // Apply current configuration
             this.setVisibility.SHOW   = 1; // Temporarily show statusline
             this.setVisibility.HIDE   = 2; // Temporarily hide statusline
+            this.setVisibility.TOGGLE = 3; // Cycle through all three modes (auto, visible, hidden)
 
             this.setVisibility.contentSeparator = highlight.get('ContentSeparator').value;
             this.setVisibility.isVisible = true;
@@ -195,6 +196,14 @@ const StatusLine = Module("statusline", {
                 // Only hide when in auto+fullscreen or hidden.
                 if ((mode == "auto" && window.fullScreen) || mode == "hidden") {
                     hideStatusline();
+                }
+                break;
+
+            case sv.TOGGLE:
+                switch (mode) {
+                    case "auto":    options["statuslinevisibility"] = "visible"; break;
+                    case "visible": options["statuslinevisibility"] = "hidden";  break;
+                    case "hidden":  options["statuslinevisibility"] = "auto";    break;
                 }
                 break;
         }


### PR DESCRIPTION
Please see this as a DRAFT only (or improve it or merge it if you're happy).

The previous implementation with various state variables was somehow confusing. I tried another approach with modes and events (still via a single interface method `setVisibility(request)`).

There are three modes:

1. `AUTO`: This shows or hides the statusline depending on the fullscreen state.
2. `ON`: Here the statusline is always visible, even in fullscreen.
3. `OFF`: The statusline is hidden, only the commandline is shown after typing a colon.

Several events can happen:

1. `FULLSCREEN`: Whenever the fullscreen state changes.
2. `TOGGLE`: Cycles through all three modes. Currently there's no indicator, so it's not easy with three modes instead of two.
3. `SHOW` and `HIDE`: These are emitted when entering or leaving the commandline.

I have a very strong feeling that there's a better way. Compared to #407 this has the advantage that you have three modes and that the code might be a little bit more readable.