### PR TITLE
Findbar fixes

### DIFF
--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -421,6 +421,16 @@ const CommandLine = Module("commandline", {
         }
     },
 
+    _isIMEComposing: false,
+
+    onCompositionStart: function(e) {
+        this._isIMEComposing = true;
+    },
+
+    onCompositionEnd: function(e) {
+        this._isIMEComposing = false;
+    },
+
     get command() {
         try {
             // The long path is because of complications with the
@@ -1528,6 +1538,12 @@ const CommandLine = Module("commandline", {
                 completer: function (context) completion.ex(context),
                 literal: 0
             });
+    },
+    events: function() {
+        // The commandline should know when the user is inputting complex text, some functionalities may depend on it; i.e. finder.js
+        let textbox = document.getElementById("liberator-commandline-command");
+        events.addSessionListener(textbox, "compositionstart", this.closure.onCompositionStart);
+        events.addSessionListener(textbox, "compositionend", this.closure.onCompositionEnd);
     },
     mappings: function () {
         var myModes = [modes.COMMAND_LINE];

--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -290,18 +290,6 @@ var Finder = Module("finder", {
             function () { finder.clear(); },
             { argCount: "0" });
     },
-    events: function() {
-        if (config.name == 'Vimperator') {
-            // Same thing as the note above for not showing the findbar on failed results
-            // through the command line, but for compatibility with FindBar Tweak.
-            events.addSessionListener(window, "WillOpenFindBar", function (event) {
-                if (commandline._keepOpenForInput) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                }
-            }, true);
-        }
-    },
     mappings: function () {
         var myModes = config.browserModes;
         myModes = myModes.concat([modes.CARET]);

--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -176,7 +176,12 @@ var Finder = Module("finder", {
      */
     onFindResult: function(aData) {
         if (aData.result == Ci.nsITypeAheadFind.FIND_NOTFOUND) {
-            liberator.echoerr("Pattern not found: " + aData.searchString, commandline.FORCE_SINGLELINE);
+            // Don't use aData.searchString, it may be a substring of the
+            // user's actual input text and that can be confusing.
+            // See https://github.com/vimperator/vimperator-labs/issues/401#issuecomment-180522987
+            // for an example.
+            let searchString = this.findbar._findField.value;
+            liberator.echoerr("Pattern not found: " + searchString, commandline.FORCE_SINGLELINE);
         }
         else if (aData.result == Ci.nsITypeAheadFind.FIND_WRAPPED) {
             let msg = aData.findBackwards ? "Search hit TOP, continuing at BOTTOM" : "Search hit BOTTOM, continuing at TOP";

--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -100,7 +100,11 @@ var Finder = Module("finder", {
         this._backwards = mode == modes.SEARCH_BACKWARD;
         //commandline.open(this._backwards ? "Find backwards" : "Find", "", mode);
         commandline.input(this._backwards ? "Find backwards" : "Find", this.closure.onSubmit, {
-            onChange: function() { if (options["incsearch"]) finder.find(commandline.command) }
+            onChange: function() {
+                if (options["incsearch"] && !commandline._isIMEComposing) {
+                    finder.find(commandline.command);
+                }
+            }
         });
         //modes.extended = mode;
 


### PR DESCRIPTION
Fixes #401:
- Don't find immediately on every key pressed while typing complex words (IME compositing).
- Don't show the findbar when searching through the command line and there are no matches.