### PR TITLE
Add zoomlevel status option

### DIFF
--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -258,6 +258,7 @@ const Buffer = Module("buffer", {
             statusline.updateField("location");
             statusline.updateField("bookmark");
             statusline.updateField("history");
+            statusline.updateField("zoomlevel");
 
             // This is a bit scary but we trigger ignore mode when the new URL is in the list
             // of pages with ignored keys and then exit it on a new page but ONLY, if:
@@ -413,6 +414,18 @@ const Buffer = Module("buffer", {
      */
     get textZoom() config.browser.markupDocumentViewer.textZoom * 100,
     set textZoom(value) { Buffer.setZoom(value, false); },
+
+    /**
+     * @property {number} The current browser's zoom level, as a
+     *     percentage with 100 as 'normal'.
+     */
+    get zoomLevel() {
+        let v = config.browser.markupDocumentViewer;
+        if (v == null)
+            return this.ZoomManager.zoom * 100;
+
+        return v[v.textZoom == 1 ? "fullZoom" : "textZoom"] * 100;
+    },
 
     /**
      * @property {number} The current browser's text zoom level, as a
@@ -1031,6 +1044,8 @@ const Buffer = Module("buffer", {
         if ("FullZoom" in window)
             FullZoom._applyZoomToPref(browser);
         liberator.echomsg((fullZoom ? "Full" : "Text") + " zoom: " + value + "%");
+        
+        statusline.updateField("zoomlevel", value);
     },
 
     bumpZoomLevel: function bumpZoomLevel(steps, fullZoom) {

--- a/common/content/events.js
+++ b/common/content/events.js
@@ -1184,6 +1184,7 @@ const Events = Module("events", {
             autocommands.trigger("Fullscreen", { state: this._fullscreen });
             statusline.setVisibility(statusline.setVisibility.UPDATE);
         }
+        statusline.updateField("zoomlevel");
     }
 }, {
     isInputElemFocused: function () {

--- a/common/content/liberator.xul
+++ b/common/content/liberator.xul
@@ -97,6 +97,7 @@
                         <label id="liberator-status-bookmark"/>
                         <label id="liberator-status-tabcount"/>
                         <label id="liberator-status-position"/>
+                        <label id="liberator-status-zoomlevel"/>
                     </toolbaritem>
                 </toolbar>
                 <hbox id="liberator-commandline" class="liberator-container" liberator:highlight="CmdLine">

--- a/common/content/statusline.js
+++ b/common/content/statusline.js
@@ -392,6 +392,32 @@ const StatusLine = Module("statusline", {
 
                 node.value = bufferPositionStr;
             });
+        statusline.addField("zoomlevel", "The main content's zoom level", "liberator-status-zoomlevel",
+            /**
+             * Display the main content's zoom level.
+             *
+             * @param {Element} node
+             * @param {number} percent The position, as a percentage. @optional
+             * @param {boolean} full True if full zoom is in operation. @optional
+             */
+            function updateZoomLevel (node, percent, full) {
+                if (typeof(buffer) == "undefined")
+                    return;
+
+                if (!percent || typeof percent != "number") {
+                    percent = buffer.zoomLevel;
+                }
+                
+                if (percent == 100)
+                    node.value = "";
+                else {
+                    percent = ("  " + Math.round(percent)).substr(-3);
+                    if (full)
+                        node.value = " [" + percent + "%]";
+                    else
+                        node.value = " (" + percent + "%)";
+                }
+            });
 
     },
     options: function () {

--- a/common/content/statusline.js
+++ b/common/content/statusline.js
@@ -407,15 +407,12 @@ const StatusLine = Module("statusline", {
                 if (!percent || typeof percent != "number") {
                     percent = buffer.zoomLevel;
                 }
-                
+
                 if (percent == 100)
                     node.value = "";
                 else {
                     percent = ("  " + Math.round(percent)).substr(-3);
-                    if (full)
-                        node.value = " [" + percent + "%]";
-                    else
-                        node.value = " (" + percent + "%)";
+                    node.value = "zoom: " + percent + "%";
                 }
             });
 

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -737,6 +737,7 @@
                                     the total number of tabs in the current window.</dd>
             <dt>position</dt>   <dd>The vertical scroll position</dd>
             <dt>ssl</dt>        <dd>Show an icon when the current buffer is connecting with SSL.</dd>
+            <dt>zoomlevel</dt>  <dd>The main content's zoom level</dd>
         </dl>
     </description>
 </item>

--- a/common/locale/ja/options.xml
+++ b/common/locale/ja/options.xml
@@ -740,6 +740,7 @@
             <dt>tabcount</dt>   <dd>現Windowのタブ数と現タブの位置を [タブ位置/タブ数] で示します</dd>
             <dt>position</dt>   <dd>スクロール位置を示します</dd>
             <dt>ssl</dt>        <dd>SSL接続している場合にアイコンを表示します</dd>
+            <dt>zoomlevel</dt>  <dd></dd>
         </dl>
     </description>
 </item>

--- a/muttator/content/compose/liberator.xul
+++ b/muttator/content/compose/liberator.xul
@@ -98,6 +98,7 @@
                         <label id="liberator-status-bookmark"/>
                         <label id="liberator-status-tabcount"/>
                         <label id="liberator-status-position"/>
+                        <label id="liberator-status-zoomlevel"/>
                     </toolbaritem>
                 </toolbar>
                 <hbox id="liberator-commandline" class="liberator-container" liberator:highlight="CmdLine">


### PR DESCRIPTION
Inspired by Pentadactyl which already has this option, this adds the webpage's zoom level to the statusline, e.g. (110%). It can be set with `set status=zoomlevel`.

Enjoy.