### PR TITLE
Find fixes

### DIFF
--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -230,6 +230,15 @@ var Finder = Module("finder", {
             this.find(pattern);
         }
 
+        // It won't send a message to find in this case, as it will assume the searched word doesn't exist,
+        // so our onFindResult listener won't be triggered. Simulate it here.
+        if (findbar._findFailedString && this._lastSearchPattern.startsWith(findbar._findFailedString)) {
+            this.onFindResult({ result: Ci.nsITypeAheadFind.FIND_NOTFOUND });
+
+            // There's also no point in continuing if there are no matches.
+            return;
+        }
+
         // TODO: move to find() when reverse incremental searching is kludged in
         // need to find again for reverse searching
         if (this._backwards)

--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -113,13 +113,9 @@ var Finder = Module("finder", {
     },
 
     /**
-     * Searches the current buffer for <b>str</b>.
-     *
-     * @param {string} str The string to find.
+     * Initialize some of the findbar's methods to play nice us.
      */
-    find: function (str) {
-        this._processUserPattern(str);
-
+    setupFindbar: function() {
         let findbar = this.findbar;
         if (!findbar.vimperated) {
             findbar.vimperated = true;
@@ -151,8 +147,18 @@ var Finder = Module("finder", {
                 return this._vimpbackup_open(aMode);
             };
         }
+    },
 
-        findbar._find();
+    /**
+     * Searches the current buffer for <b>str</b>.
+     *
+     * @param {string} str The string to find.
+     */
+    find: function (str) {
+        this.setupFindbar();
+        this._processUserPattern(str);
+
+        this.findbar._find();
     },
 
     /**
@@ -167,6 +173,7 @@ var Finder = Module("finder", {
         if (!this._lastSearchPattern)
             return;
 
+        this.setupFindbar();
         if (this._lastSearchPattern != this.findbar._findField.value)
 	    this._processUserPattern(this._searchPattern);
 
@@ -236,6 +243,7 @@ var Finder = Module("finder", {
      * Highlights all occurances of <b>str</b> in the buffer.
      */
     highlight: function () {
+        this.setupFindbar();
         let findbar = this.findbar;
 
         let btn = findbar.getElement("highlight");
@@ -251,6 +259,7 @@ var Finder = Module("finder", {
         if (!this.findbarInitialized)
             return;
 
+        this.setupFindbar();
         let findbar = this.findbar;
 
         let btn = findbar.getElement("highlight");
@@ -263,6 +272,7 @@ var Finder = Module("finder", {
      * Updates the case sensitivity parameter.
      */
     updateCaseSensitive: function (cs) {
+        this.setupFindbar();
         let findbar = this.findbar;
         if (cs != findbar._typeAheadCaseSensitive) {
             findbar._setCaseSensitivity(cs);
@@ -273,6 +283,7 @@ var Finder = Module("finder", {
      * Updates the find mode to show only matches in links or all matches.
      */
     updateFindMode: function (fm) {
+        this.setupFindbar();
         let findbar = this.findbar;
 
         // We need to pretend like we're opening the findbar with a different mode,

--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -143,7 +143,7 @@ var Finder = Module("finder", {
             // - or notify the user somehow in the command line itself?
             findbar._vimpbackup_open = findbar.open;
             findbar.open = function (aMode) {
-                if (commandline._keepOpenForInput) { return false; }
+                if (commandline._keepOpenForInput || this._vimp_keepClosed) { return false; }
                 return this._vimpbackup_open(aMode);
             };
         }
@@ -177,6 +177,9 @@ var Finder = Module("finder", {
         if (this._lastSearchPattern != this.findbar._findField.value)
 	    this._processUserPattern(this._searchPattern);
 
+        // We don't want to show the findbar on failed searches when using the commandline.
+        this.findbar._vimp_keepClosed = true;
+
         this.findbar.onFindAgainCommand(reverse);
     },
 
@@ -185,6 +188,7 @@ var Finder = Module("finder", {
      * this is done aSync from the main (input) process.
      */
     onFindResult: function(aData) {
+        this.findbar._vimp_keepClosed = false;
         if (aData.result == Ci.nsITypeAheadFind.FIND_NOTFOUND) {
             // Don't use aData.searchString, it may be a substring of the
             // user's actual input text and that can be confusing.


### PR DESCRIPTION
Fixes for https://github.com/vimperator/vimperator-labs/issues/426#issuecomment-190651015 - we were initializing the findbar only when typing in the cmdline, it completely neglected to do this in all other find actions.

And a couple of other things I noticed while working on it:

- it would still show only a substring of the typed query sometimes in the failed search notification in the cmdline, because the findbar keeps track of failed searches (somewhat) and doesn't actually run a search that we can listen to for results to show this notification;
- pressing "n" would still show the findbar on failed searches, since the cursor isn't actually in the cmdline in this case which is what it was checking for before.