### PR TITLE
Add PluginsLoadPost autocommand

### DIFF
--- a/common/content/liberator.js
+++ b/common/content/liberator.js
@@ -715,6 +715,7 @@ const Liberator = Module("liberator", {
 
         if (dirs.length == 0) {
             liberator.log("No user plugin directory found");
+            autocommands.trigger("PluginsLoadPost", {});
             return;
         }
 
@@ -726,6 +727,7 @@ const Liberator = Module("liberator", {
             liberator.log("Searching for \"" + (dir.path + "/**/*.{js,vimp}") + "\"", 3);
             sourceDirectory(dir);
         });
+        autocommands.trigger("PluginsLoadPost", {});
     },
 
     /**

--- a/muttator/locale/en-US/autocommands.xml
+++ b/muttator/locale/en-US/autocommands.xml
@@ -15,6 +15,7 @@
     <dt>LocationChange</dt>    <dd>Triggered when changing tabs or when navigating to a new location</dd>
     <dt>PageLoadPre</dt>       <dd>Triggered after a page load is initiated</dd>
     <dt>PageLoad</dt>          <dd>Triggered when a page gets (re)loaded/opened</dd>
+    <dt>PluginsLoadPost</dt>   <dd>Triggered after all plugins have been (re)loaded</dd>
     <dt>ShellCmdPost</dt>      <dd>Triggered after executing a shell command with <ex>:!</ex><a>cmd</a></dd>
     <dt>&liberator.appname;Enter</dt>   <dd>Triggered after &liberator.host; starts</dd>
     <dt>&liberator.appname;LeavePre</dt><dd>Triggered before exiting &liberator.host;, just before destroying each module</dd>

--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -1,4 +1,5 @@
 201x-xx-xx:
+    * add *PluginsLoadPost* autocmd event
 
 2016-02-28:
     * @kmorihiro fixed background color theming for statusline

--- a/vimperator/content/config.js
+++ b/vimperator/content/config.js
@@ -27,6 +27,7 @@ var Config = Module("config", ConfigBase, {
                    ["LocationChange",     "Triggered when changing tabs or when navigation to a new location"],
                    ["PageLoadPre",        "Triggered after a page load is initiated"],
                    ["PageLoad",           "Triggered when a page gets (re)loaded/opened"],
+                   ["PluginsLoadPost",    "Triggered after all plugins have been (re)loaded"],
                    // TODO: remove when FF ESR's version is over 20
                    ["PrivateMode",        "Triggered when private mode is activated or deactivated"],
                    ["Sanitize",           "Triggered when a sanitizeable item is cleared"],

--- a/vimperator/contrib/vim/syntax/vimperator.vim
+++ b/vimperator/contrib/vim/syntax/vimperator.vim
@@ -43,7 +43,7 @@ syn match vimperatorCommand "!" contained
 syn keyword vimperatorAutoCmd au[tocmd] contained nextgroup=vimperatorAutoEventList skipwhite
 
 syn keyword vimperatorAutoEvent BookmarkAdd ColorSheme DOMLoad DownloadPost Fullscreen LocationChange PageLoadPre PageLoad
-    \ PrivateMode Sanitize ShellCmdPost VimperatorEnter VimperatorLeavePre VimperatorLeave
+    \ PluginsLoadPost PrivateMode Sanitize ShellCmdPost VimperatorEnter VimperatorLeavePre VimperatorLeave
     \ contained
 
 syn match vimperatorAutoEventList "\(\a\+,\)*\a\+" contained contains=vimperatorAutoEvent

--- a/vimperator/locale/en-US/autocommands.xml
+++ b/vimperator/locale/en-US/autocommands.xml
@@ -16,6 +16,7 @@
     <dt>LocationChange</dt>    <dd>Triggered when changing tabs or when navigating to a new location</dd>
     <dt>PageLoadPre</dt>       <dd>Triggered after a page load is initiated</dd>
     <dt>PageLoad</dt>          <dd>Triggered when a page gets (re)loaded/opened</dd>
+    <dt>PluginsLoadPost</dt>   <dd>Triggered after all plugins have been (re)loaded</dd>
     <dt>PrivateMode</dt>       <dd>Triggered when private mode is activated or deactivated</dd>
     <dt>Sanitize</dt>	       <dd>Triggered when privata data are sanitized</dd>
     <dt>ShellCmdPost</dt>      <dd>Triggered after executing a shell command with <ex>:!</ex><a>cmd</a></dd>

--- a/vimperator/locale/ja/autocommands.xml
+++ b/vimperator/locale/ja/autocommands.xml
@@ -16,6 +16,7 @@
     <dt>LocationChange</dt>    <dd>タブを切り替えた際や新しい URL に移動した際に発生します</dd>
     <dt>PageLoadPre</dt>       <dd>ページの読み込みが開始された直後に発生します</dd>
     <dt>PageLoad</dt>          <dd>ページの ( 再 ) 読み込みが終了した際やページが開かれた際に発生します</dd>
+    <dt>PluginsLoadPost</dt>   <dd>Triggered after all plugins have been (re)loaded</dd>
     <dt>PrivateMode</dt>       <dd>プライベートブラウジングに切り替えた際と元に戻った際に発生します</dd>
     <dt>Sanitize</dt>	       <dd>プライベートデータを削除した際に発生します</dd>
     <dt>ShellCmdPost</dt>      <dd><ex>:!</ex><a>cmd</a> でシェルコマンドが実行された直後に発生します</dd>


### PR DESCRIPTION
Useful for handling interdependencies between plugins without relying on
io.readDirectory()s sorting.