### PR TITLE
Unbreak Muttator on Thunderbird 45 (var/const scoping for Config module)

### DIFF
--- a/muttator/content/config.js
+++ b/muttator/content/config.js
@@ -5,7 +5,7 @@
 
 const DEFAULT_FAVICON = "chrome://global/skin/icons/Portrait.png";
 
-const Config = Module("config", ConfigBase, {
+var Config = Module("config", ConfigBase, {
     init: function () {
         // don't wait too long when selecting new messages
         // GetThreadTree()._selectDelay = 300; // TODO: make configurable


### PR DESCRIPTION
This unbreaks Muttator on Thunderbird 45 for me. The same workaround is
already committed for Vimperator:

https://github.com/vimperator/vimperator-labs/issues/289#issuecomment-158372213