### PR TITLE
Don't use Application anymore. FUEL is removed

### DIFF
--- a/common/content/base.js
+++ b/common/content/base.js
@@ -333,7 +333,9 @@ function Class() {
     }
 
     extend(Constructor, superclass, args[0]);
-    update(Constructor, args[1]);
+    if (args[1]) {
+        update(Constructor, args[1]);
+    }
     args = args.slice(2);
     Array.forEach(args, function (obj) {
         if (callable(obj))

--- a/common/content/io.js
+++ b/common/content/io.js
@@ -7,6 +7,8 @@
 
 /** @scope modules */
 
+const VERSION = Services.appinfo.platformVersion;
+
 plugins.contexts = {};
 const Script = Class("Script", {
     init: function (file) {
@@ -330,7 +332,7 @@ const IO = Module("io", {
         this._lastRunCommand = ""; // updated whenever the users runs a command with :!
         this._scriptNames = [];
 
-        if (services.get("vc").compare(Application.version, "26.0a1") < 0) {
+        if (services.get("vc").compare(VERSION, "26.0a1") < 0) {
             this.downloadListener = {
                 onDownloadStateChange: function (state, download) {
                     if (download.state == services.get("downloads").DOWNLOAD_FINISHED) {
@@ -372,7 +374,7 @@ const IO = Module("io", {
     },
 
     destroy: function () {
-        if (services.get("vc").compare(Application.version, "26.0a1") < 0) {
+        if (services.get("vc").compare(VERSION, "26.0a1") < 0) {
             services.get("downloads").removeListener(this.downloadListener);
         } else {
             let {Downloads} = Cu.import("resource://gre/modules/Downloads.jsm", {});

--- a/common/content/preferences.xul
+++ b/common/content/preferences.xul
@@ -5,7 +5,7 @@
         let uri = Components.classes["@mozilla.org/network/io-service;1"]
                             .getService(Components.interfaces.nsIIOService)
                             .newURI("liberator://help/options", null, null);
-        Application.activeWindow.open(uri).focus(); // TODO: generalise for Muttator et al.
+        <!--Application.activeWindow.open(uri).focus(); // TODO: generalise for Muttator et al.-->
         window.close();
     </script>
 </window>

--- a/common/content/util.js
+++ b/common/content/util.js
@@ -426,7 +426,7 @@ const Util = Module("util", {
             null
         );
 
-        if (services.get("vc").compare(Application.version, "33") >= 0
+        if (services.get("vc").compare(VERSION, "33") >= 0
             && Cu.isXrayWrapper(result)) {
             let xr = result;
 


### PR DESCRIPTION
This makes vimperator work with firefox 47 again.
I'm not sure what the implications for older firefox but it probably would work as far back as 40, if not longer.