### PR TITLE
Remove unnecessary Iterator loop in history.get

### DIFF
--- a/common/content/history.js
+++ b/common/content/history.js
@@ -17,8 +17,7 @@ const History = Module("history", {
 
         if (typeof filter == "string")
             filter = { searchTerms: filter };
-        for (let [k, v] in Iterator(filter))
-            query[k] = v;
+
         options.sortingMode = options.SORT_BY_DATE_DESCENDING;
         options.resultType = options.RESULTS_AS_URI;
         if (maxItems > 0)


### PR DESCRIPTION
This seems to be not necessary and it is causing issues particularly in
firefox 47, there query is a "XPCWrappedNative_NoHelper" and we can't
modify it which is what this loop tries to do.
Wrapping it in a try/catch does fix the issue as well but removing it
altogether seems to also fix it and seems that there are no adverse
effects.

Can someone give this a shot on various some versions of firefox?