### PR TITLE
fix Shift+Insert paste on Linux

### DIFF
--- a/common/content/editor.js
+++ b/common/content/editor.js
@@ -83,7 +83,8 @@ const Editor = Module("editor", {
                 let rangeEnd = elem.selectionEnd;
                 let tempStr1 = elem.value.substring(0, rangeStart);
                 let tempStr2 = util.readFromClipboard();
-                elem.value = tempStr1 + tempStr2;
+                let tempStr3 = elem.value.substring(rangeEnd);
+                elem.value = tempStr1 + tempStr2 + tempStr3;
                 elem.selectionStart = rangeStart + tempStr2.length;
                 elem.selectionEnd = elem.selectionStart;
     


### PR DESCRIPTION
Do not delete the text after the cursor/selection. Fix #560.