### PR TITLE
Change option 'previouspattern' to 'prevpattern'.

### DIFF
--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -1648,7 +1648,7 @@ const Buffer = Module("buffer", {
 
         mappings.add(myModes, ["[["],
             "Follow the link labeled 'prev', 'previous' or '<' if it exists",
-            function (count) { buffer.followDocumentRelationship("previous"); },
+            function (count) { buffer.followDocumentRelationship("prev"); },
             { count: true });
 
         mappings.add(myModes, ["gf"],
@@ -1789,7 +1789,7 @@ const Buffer = Module("buffer", {
             "Patterns to use when guessing the 'next' page in a document sequence",
             "stringlist", "\\bnext\\b,^>$,^(>>|\u00BB)$,^(>|\u00BB),(>|\u00BB)$,\\bmore\\b");
 
-        options.add(["previouspattern"], // \u00AB is « (<< in a single char)
+        options.add(["prevpattern", "previouspattern"], // \u00AB is « (<< in a single char)
             "Patterns to use when guessing the 'previous' page in a document sequence",
             "stringlist", "\\bprev|previous\\b,^<$,^(<<|\u00AB)$,^(<|\u00AB),(<|\u00AB)$");
 

--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -556,15 +556,17 @@ const Buffer = Module("buffer", {
      *     "pattern", and finds the last link matching that
      *     RegExp.
      */
-    followDocumentRelationship: function (rel) {
+    followDocumentRelationship: function (rel, ...synonyms) {
         let regexes = options.get(rel + "pattern").values
                              .map(function (re) RegExp(re, "i"));
+        synonyms.unshift(rel);
 
         function followFrame(frame) {
             function iter(elems) {
                 for (let i = 0; i < elems.length; i++)
-                    if (elems[i].rel.toLowerCase() == rel || elems[i].rev.toLowerCase() == rel)
-                        yield elems[i];
+                    for (let rel of synonyms)
+                        if (elems[i].rel.toLowerCase() == rel || elems[i].rev.toLowerCase() == rel)
+                            yield elems[i];
             }
 
             // <link>s have higher priority than normal <a> hrefs
@@ -1648,7 +1650,7 @@ const Buffer = Module("buffer", {
 
         mappings.add(myModes, ["[["],
             "Follow the link labeled 'prev', 'previous' or '<' if it exists",
-            function (count) { buffer.followDocumentRelationship("prev"); },
+            function (count) { buffer.followDocumentRelationship("prev", "previous"); },
             { count: true });
 
         mappings.add(myModes, ["gf"],

--- a/common/locale/en-US/buffer.xml
+++ b/common/locale/en-US/buffer.xml
@@ -327,7 +327,7 @@
             Follow the link labeled <str>prev</str>,
             <str>previous</str> or <str>&lt;</str> if it exists. Useful
             when browsing forums or documentation. Change
-            <o>previouspattern</o> to modify its behavior. It
+            <o>prevpattern</o> to modify its behavior. It
             follows relations between files too.
         </p>
     </description>

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -937,8 +937,8 @@
 
 
 <item>
-    <tags>'previouspattern'</tags>
-    <spec>'previouspattern'</spec>
+    <tags>'prevpattern' 'previouspattern'</tags>
+    <spec>'prevpattern' 'previouspattern'</spec>
     <type>stringlist</type>
     <default><![CDATA[\bprev|previous\b,^<$,^(<<|«)$,^(<|«),(<|«)$]]></default>
     <description>

--- a/common/locale/ja/buffer.xml
+++ b/common/locale/ja/buffer.xml
@@ -338,7 +338,7 @@
         <p>
             <str>prev</str> 、<str>previous</str> や <str>&lt;</str> という名前のリンクが存在する場合、それを辿ります。
             掲示板や説明書を読むときに便利です。
-            <o>previouspattern</o> オプションで挙動を変更できます。
+            <o>prevpattern</o> オプションで挙動を変更できます。
             ファイル間の関連も辿ることができます。
         </p>
     </description>

--- a/common/locale/ja/index.xml
+++ b/common/locale/ja/index.xml
@@ -414,7 +414,7 @@
     <dt><o>online</o></dt> <dd>'オフライン作業' にするかどうかを設定します</dd>
     <dt><o>pageinfo</o></dt> <dd><ex>:pageinfo</ex> で表示したい情報を設定します</dd>
     <dt><o>popups</o></dt> <dd>ポップアップウィンドウを表示する場所を設定します</dd>
-    <dt><o>previouspattern</o></dt> <dd>現在のページの '前' のページを推測するためのパターンを設定します</dd>
+    <dt><o>prevpattern</o></dt> <dd>現在のページの '前' のページを推測するためのパターンを設定します</dd>
     <dt><o>private</o></dt> <dd>'プライベートブラウジング'に設定します</dd>
     <dt><o>runtimepath</o></dt> <dd>ランタイムファイルが存在するディレクトリの一覧を設定します</dd>
     <dt><o>sanitizeitems</o></dt> <dd>個人データを削除するアイテムを設定します</dd>

--- a/common/locale/ja/options.xml
+++ b/common/locale/ja/options.xml
@@ -917,8 +917,8 @@
 
 
 <item>
-    <tags>'previouspattern'</tags>
-    <spec>'previouspattern'</spec>
+    <tags>'prevpattern' 'previouspattern'</tags>
+    <spec>'prevpattern' 'previouspattern'</spec>
     <type>stringlist</type>
     <default><![CDATA[\bprev|previous\b,^<$,^(<<|«)$,^(<|«),(<|«)$]]></default>
     <description>

--- a/muttator/contrib/vim/syntax/muttator.vim
+++ b/muttator/contrib/vim/syntax/muttator.vim
@@ -48,7 +48,7 @@ syn region muttatorSet matchgroup=muttatorCommand start="\%(^\s*:\=\)\@<=\<\%(se
 
 syn keyword muttatorOption archivefolder autocomplete ac cdpath cd complete cpt editor eventignore ei extendedhinttags eht fileencoding fenc
     \ followhints fh guioptions go helpfile hf hintinputs hin hintmatching hm hinttags ht hinttimeout hto history hi
-    \ layout maxitems messages msgs nextpattern pageinfo pa previouspattern runtimepath rtp scroll scr shell sh shellcmdflag shcf
+    \ layout maxitems messages msgs nextpattern pageinfo pa prevpattern previouspattern runtimepath rtp scroll scr shell sh shellcmdflag shcf
     \ showstatuslinks ssli status smtpserver smtp suggestengines titlestring urlseparator verbose vbs
     \ wildmode wim wop wordseparators wsp
     \ contained nextgroup=muttatorSetMod


### PR DESCRIPTION
For backward compatibility, 'previouspattern' remains valid.

The reason for this change: "prev" is the standard LINK TYPE, while
"previous" is an often supported (but incorrect) synonym. Therefore,
followDocumentRelationship("prev") is preferred.

Reference:
https://www.w3.org/TR/html4/types.html#type-links
https://www.w3.org/TR/html5/links.html#sequential-link-types
https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types