### PR TITLE
Canonicalize commandline history during matching

### DIFF
--- a/common/content/browser.js
+++ b/common/content/browser.js
@@ -238,6 +238,7 @@ const Browser = Module("browser", {
                 else
                     liberator.open("");
             }, {
+                canonicalize: function (cmd) cmd.replace(/^(op?|open?)\b/, 'open'),
                 completer: function (context) completion.url(context),
                 literal: 0,
                 privateData: true

--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -1088,6 +1088,21 @@ const CommandLine = Module("commandline", {
             this.store.truncate(options.history, true);
         },
         /**
+         * @property {function} Returns a canonical form of the argument that
+         * can be used for comparison.
+         */
+        canonicalize: function (str) {
+            // Not really the ideal place for this check.
+            if (this.mode != "command")
+                return str;
+
+            let cmd = (commands.get(commands.parseCommand(str)[1]) || {});
+            if (cmd.canonicalize != undefined)
+                return cmd.canonicalize(str);
+
+            return str;
+        },
+        /**
          * @property {function} Returns whether a data item should be
          * considered private.
          */
@@ -1140,6 +1155,7 @@ const CommandLine = Module("commandline", {
 
             // search the this._history for the first item matching the current
             // commandline string
+            let canonical_original = this.canonicalize(this.original);
             while (true) {
                 this.index += diff;
                 if (this.index < 0 || this.index > this.store.length) {
@@ -1162,8 +1178,10 @@ const CommandLine = Module("commandline", {
                 else
                     hist = (hist.value || hist);
 
-                if (!matchCurrent || hist.substr(0, this.original.length) == this.original) {
-                    this.replace(hist);
+                let canonical_hist = this.canonicalize(hist);
+                if (!matchCurrent ||
+                    canonical_hist.substr(0, canonical_original.length) == canonical_original) {
+                    this.replace(this.original + canonical_hist.substr(canonical_original.length));
                     break;
                 }
             }

--- a/common/content/commands.js
+++ b/common/content/commands.js
@@ -22,15 +22,16 @@
  * @param {function} action The action invoked by this command when executed.
  * @param {Object} extraInfo An optional extra configuration hash. The
  *     following properties are supported.
- *         argCount    - see {@link Command#argCount}
- *         bang        - see {@link Command#bang}
- *         completer   - see {@link Command#completer}
- *         count       - see {@link Command#count}
- *         heredoc     - see {@link Command#heredoc}
- *         literal     - see {@link Command#literal}
- *         options     - see {@link Command#options}
- *         serial      - see {@link Command#serial}
- *         privateData - see {@link Command#privateData}
+ *         argCount     - see {@link Command#argCount}
+ *         bang         - see {@link Command#bang}
+ *         canonicalize - see {@link Command#canonicalize}
+ *         completer    - see {@link Command#completer}
+ *         count        - see {@link Command#count}
+ *         heredoc      - see {@link Command#heredoc}
+ *         literal      - see {@link Command#literal}
+ *         options      - see {@link Command#options}
+ *         serial       - see {@link Command#serial}
+ *         privateData  - see {@link Command#privateData}
  * @optional
  * @private
  */
@@ -158,6 +159,13 @@ const Command = Class("Command", {
      * @see Commands#parseArgs
      */
     argCount: 0,
+    /**
+     * @property {function (string)} Transforms command line string to its
+     * canonical form.
+     */
+    canonicalize: function(cmd) {
+        return cmd.replace(new RegExp('^(' + this.names.join('|') + ')\\b'), this.name);
+    },
     /**
      * @property {function (CompletionContext, Args)} This command's completer.
      * @see CompletionContext

--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -879,6 +879,7 @@ const Tabs = Module("tabs", {
                         liberator.open("", { where: where });
                 }, {
                     bang: true,
+                    canonicalize: function (cmd) cmd.replace(/^(to?|tope?|topen|tabopen|tabnew)\b/, 'open'),
                     completer: function (context) completion.url(context),
                     literal: 0,
                     privateData: true

--- a/vimperator/content/config.js
+++ b/vimperator/content/config.js
@@ -249,6 +249,7 @@ var Config = Module("config", ConfigBase, {
                 options: [
                     [["-private", "-p"], commands.OPTION_NOARG],
                 ],
+                canonicalize: function (cmd) cmd.replace(/^(winop?|winopen?)\b/, 'open'),
                 completer: function (context) completion.url(context),
                 literal: 0,
                 privateData: true


### PR DESCRIPTION
This allows finding all commands regardless of which command name
was used. E.g. :js <Up> matches on :js, :javas and :javascript.

We special case :open/:tabopen/:winopen, which which are treated the
same. Allowing e.g. :open retrieve URLs that were previously used with
:tabopen.