### PR TITLE
Fixes and refactor in hints module

### DIFF
--- a/common/content/events.js
+++ b/common/content/events.js
@@ -966,14 +966,9 @@ const Events = Module("events", {
                     throw killEvent();
                 }
 
-                // All of these special cases for hint mode are driving
-                // me insane! -Kris
                 if (modes.extended & modes.HINTS) {
                     // under HINT mode, certain keys are redirected to hints.onEvent
-                    if (key == "<Return>" || key == "<Tab>" || key == "<S-Tab>"
-                        || key == mappings.getMapLeader()
-                        || (key == "<BS>" && hints.previnput == "number")
-                        || (hints._isHintNumber(key) && !hints.escNumbers)) {
+                    if (hints.canHandleKey(key)) {
                         hints.onEvent(event);
                         this._input.buffer = "";
                         throw killEvent();

--- a/common/content/events.js
+++ b/common/content/events.js
@@ -878,14 +878,15 @@ const Events = Module("events", {
         let url = typeof(buffer) != "undefined" ? buffer.URL : "";
 
         if (modes.isRecording) {
-            if (key == "q" && liberator.mode != modes.INSERT && liberator.mode != modes.TEXTAREA) { // TODO: should not be hardcoded
+            if (key == "q" && !(liberator.mode & (modes.INSERT | modes.TEXTAREA | modes.COMMAND_LINE))) { // TODO: should not be hardcoded
                 modes.isRecording = false;
                 liberator.echomsg("Recorded macro '" + this._currentMacro + "'");
                 killEvent();
                 return;
             }
-            else if (!mappings.hasMap(liberator.mode, this._input.buffer + key, url))
+            else if (!mappings.hasMap(liberator.mode, this._input.buffer + key, url)) {
                 this._macros.set(this._currentMacro, this._macros.get(this._currentMacro) + key);
+            }
         }
 
         if (key == "<C-c>")

--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -651,11 +651,11 @@ const Hints = Module("hints", {
     _checkUnique: function () {
         if (
             this._hintNumber === null ||
-            this._hintNumber === this._chars2num(options.hintchars[0])
+            this._hintNumber === this._chars2num(options.hintchars[0]) ||
+            this._hintNumber > this._validHints.length
         ) {
             return;
         }
-        liberator.assert(this._hintNumber <= this._validHints.length);
 
         // if we write a numeric part like 3, but we have 45 hints, only follow
         // the hint after a timeout, as the user might have wanted to follow link 34

--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -92,7 +92,6 @@ const Hints = Module("hints", {
         this._hintNumber = null;         // only the numerical part of the hint
         this._usedTabKey = false;        // when we used <Tab> to select an element
         this._prevInput = "";            // record previous user input type, "text" || "number"
-        this._canUpdate = false;
     },
 
     /**
@@ -939,7 +938,6 @@ const Hints = Module("hints", {
         // get all keys from the input queue
         liberator.threadYield(true);
 
-        this._canUpdate = true;
         this._showHints();
 
         if (this._validHints.length == 0) {
@@ -1008,7 +1006,6 @@ const Hints = Module("hints", {
      */
     onEvent: function (event) {
         let key = events.toString(event);
-        let followFirst = false;
 
         // clear any timeout which might be active after pressing a number
         if (this._activeTimeout) {
@@ -1018,9 +1015,8 @@ const Hints = Module("hints", {
 
         switch (key) {
         case "<Return>":
-            followFirst = true;
-            break;
-
+            this._processHints(true);
+            return;
         case "<Tab>":
         case "<S-Tab>":
             this._usedTabKey = true;
@@ -1042,7 +1038,6 @@ const Hints = Module("hints", {
                 this._hintNumber = Math.floor(this._hintNumber / 10);
                 if (this._hintNumber === 0)
                     this._resetInput();
-                    this._canUpdate = true;
             }
             else {
                 this._usedTabKey = false;
@@ -1072,13 +1067,6 @@ const Hints = Module("hints", {
 
             let oldHintNumber = this._hintNumber;
 
-            if (!this._canUpdate)
-                return;
-
-            if (this._docs.length == 0) {
-                this._generate();
-                this._showHints();
-            }
             this._showActiveHint(this._hintNumber, oldHintNumber || 1);
 
             this._checkUnique();
@@ -1086,13 +1074,11 @@ const Hints = Module("hints", {
 
         this._updateStatusline();
 
-        if (this._canUpdate) {
-            if (this._docs.length == 0 && this._hintString.length > 0)
-                this._generate();
-
-            this._showHints();
-            this._processHints(followFirst);
+        if (this._docs.length == 0 && this._hintString.length > 0) {
+            this._generate();
         }
+        this._showHints();
+        this._processHints(false);
     }
 
     // FIXME: add resize support

--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -933,7 +933,13 @@ const Hints = Module("hints", {
         this._hintString = filter || "";
         this._resetInput();
 
-        this._generate(win);
+        try {
+            this._generate(win);
+        } catch (e) {
+            setTimeout(function() {
+                hints._generate(win);
+            }, 0)
+        }
 
         // get all keys from the input queue
         liberator.threadYield(true);

--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -992,7 +992,7 @@ const Hints = Module("hints", {
     canHandleKey: function(key) {
         return (
             ["<Return>", "<Tab>", "<S-Tab>", mappings.getMapLeader()].indexOf(key) > -1 ||
-            (key == "<BS>" && hints.previnput === "number") ||
+            (key == "<BS>" && hints._prevInput === "number") ||
             (
                 hints._isHintNumber(key) &&
                 !hints.escNumbers &&
@@ -1041,7 +1041,8 @@ const Hints = Module("hints", {
             if (this._hintNumber !== null && !this._usedTabKey) {
                 this._hintNumber = Math.floor(this._hintNumber / 10);
                 if (this._hintNumber === 0)
-                    this._prevInput = "text";
+                    this._resetInput();
+                    this._canUpdate = true;
             }
             else {
                 this._usedTabKey = false;

--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -979,6 +979,17 @@ const Hints = Module("hints", {
     },
 
     /**
+     * Return true if key is a valid entry point for hints handling
+     */
+    canHandleKey: function(key) {
+        return (
+            ["<Return>", "<Tab>", "<S-Tab>", mappings.getMapLeader()].indexOf(key) > -1 ||
+            (key == "<BS>" && hints.previnput === "number") ||
+            (hints._isHintNumber(key) && !hints.escNumbers)
+        );
+    },
+
+    /**
      * Handle a hint mode event.
      *
      * @param {Event} event The event to handle.


### PR DESCRIPTION
This PR includes a few fixes on issues that I noticed or were reported by others related to links hinting (`;o`) as well as a simple refactor to move hints concerns to `hints.js` and avoid useless repetition.

A lot of problems were caused by '0' being both the initial state of hints and a valid part of two or more digits hints (when `hintchars` is numeric that is). The problem with fullscreen appears to come from a delay on the chrome being accessible in that mode... The rest is moving stuff around.

I didn't have time to test all possible cases, hence the long delay on submitting this PR, but since there was some action on a related issue, I'll just go ahead and take feedback from the community.