### PR TITLE
Fix [[ following "preview" button

### DIFF
--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -1793,7 +1793,7 @@ const Buffer = Module("buffer", {
 
         options.add(["prevpattern", "previouspattern"], // \u00AB is « (<< in a single char)
             "Patterns to use when guessing the 'previous' page in a document sequence",
-            "stringlist", "\\bprev|previous\\b,^<$,^(<<|\u00AB)$,^(<|\u00AB),(<|\u00AB)$");
+            "stringlist", "\\bprev\\b|\\bprevious\\b,^<$,^(<<|\u00AB)$,^(<|\u00AB),(<|\u00AB)$");
 
         options.add(["pageinfo", "pa"],
             "Desired info in the :pageinfo output",

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -940,7 +940,7 @@
     <tags>'prevpattern' 'previouspattern'</tags>
     <spec>'prevpattern' 'previouspattern'</spec>
     <type>stringlist</type>
-    <default><![CDATA[\bprev|previous\b,^<$,^(<<|«)$,^(<|«),(<|«)$]]></default>
+    <default><![CDATA[\bprev\b|\bprevious\b,^<$,^(<<|«)$,^(<|«),(<|«)$]]></default>
     <description>
         <p>
             Patterns to use when guessing the <o>previous</o> page in a document

--- a/common/locale/ja/options.xml
+++ b/common/locale/ja/options.xml
@@ -920,7 +920,7 @@
     <tags>'prevpattern' 'previouspattern'</tags>
     <spec>'prevpattern' 'previouspattern'</spec>
     <type>stringlist</type>
-    <default><![CDATA[\bprev|previous\b,^<$,^(<<|«)$,^(<|«),(<|«)$]]></default>
+    <default><![CDATA[\bprev\b|\bprevious\b,^<$,^(<<|«)$,^(<|«),(<|«)$]]></default>
     <description>
         <p>
             ページに分割されている文書において <o>前</o> のページを推測するために使われるパターンです。


### PR DESCRIPTION
Issue taken from real life: on a page that has both `preview` and `previous` button, `preview` has been winning rendering <kbd>[[</kbd> pretty useless.