### PR TITLE
Fix #619: Override newtab URL

### DIFF
--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -1,4 +1,5 @@
 201x-xx-xx:
+    * add option 'newtaburl' to set default URL in new tabs
 
 2016-10-05:
     * update and fix css related issues

--- a/vimperator/content/config.js
+++ b/vimperator/content/config.js
@@ -323,6 +323,29 @@ var Config = Module("config", ConfigBase, {
                 },
                 getter: function () !services.get("io").offline
             });
+
+        options.add(["newtaburl", "ntu"],
+            "Set the default page for new tabs",
+            "string", "about:newtab",
+            {
+                setter: function (value) {
+                    if (services.get("vc").compare(VERSION, "41.*") == -1) {
+                        options.setPref("browser.newtab.url", value);
+                    } else {
+                        Components.utils.import("resource:///modules/NewTabURL.jsm");
+                        NewTabURL.override(value);
+                    }
+                    return value;
+                },
+                getter: function () {
+                    if (services.get("vc").compare(VERSION, "41.*") == -1) {
+                        return options.getPref("browser.newtab.url");
+                    } else {
+                        Components.utils.import("resource:///modules/NewTabURL.jsm");
+                        return NewTabURL.get();
+                    }
+                }
+            });
     }
 });
 

--- a/vimperator/locale/en-US/options.xml
+++ b/vimperator/locale/en-US/options.xml
@@ -62,5 +62,17 @@
     </description>
 </item>
 
+<item insertafter="'newtab'">
+    <tags>'ntu' 'newtaburl'</tags>
+    <spec>'newtaburl' 'ntu'</spec>
+    <type>string</type>
+    <default>about:newtab</default>
+    <description>
+        <p>
+            The URL that will be opened in new tabs.
+        </p>
+    </description>
+</item>
+
 </overlay>
 <!-- vim:se sts=4 sw=4 et: -->


### PR DESCRIPTION
This exposes the NewTabURL API to the user and also provides a fallback
for older versions of Firefox via the browser.newtab.url preference.