### PR TITLE
statusline: add ssl by default (fixes #644)

### DIFF
--- a/common/content/statusline.js
+++ b/common/content/statusline.js
@@ -420,7 +420,7 @@ const StatusLine = Module("statusline", {
     options: function () {
         options.add(["status"],
             "Define which information to show in the status bar",
-            "stringlist", "input,location,bookmark,history,tabcount,position",
+            "stringlist", "input,location,bookmark,history,ssl,tabcount,position",
             {
                 setter: function setter(value) {
                     statusline.sortFields(this.values);

--- a/common/locale/en-US/options.xml
+++ b/common/locale/en-US/options.xml
@@ -732,7 +732,7 @@
     <tags>'status'</tags>
     <spec>'status'</spec>
     <type>stringlist</type>
-    <default>input,location,bookmark,history,tabcount,position</default>
+    <default>input,location,bookmark,history,ssl,tabcount,position</default>
     <description>
         <p>Determines which elements to show in the status bar.</p>
 

--- a/common/locale/ja/options.xml
+++ b/common/locale/ja/options.xml
@@ -736,7 +736,7 @@
     <tags>'status'</tags>
     <spec>'status'</spec>
     <type>stringlist</type>
-    <default>input,location,bookmark,history,tabcount,position</default>
+    <default>input,location,bookmark,history,ssl,tabcount,position</default>
     <description>
         <p>ステータスラインに表示する要素を示します。</p>
 


### PR DESCRIPTION
Add the SSL icon by default to the statusline for security reasons.
If `gui` is set to `none`, there is now a way to quickly check the
certificate, which is important for users to prevent them from being
harmed.