### PR TITLE
Fix #648: make xpi doesn't work

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -93,7 +93,7 @@ xpi:
 
 	# Remove existing locale entries from the manifest file
 	for locale in $(SUPPORTED_LOCALES); do \
-		sed -i -e "/$$locale/d" $(XPI_PATH)/chrome.manifest; \
+		sed -i'' -e "/$$locale/d" $(XPI_PATH)/chrome.manifest; \
 	done
 
 	# Package up locale specific documentation files
@@ -116,21 +116,21 @@ xpi:
 	done
 
 	# Update locale paths in manifest file
-	sed -i -e 's# ./locale/# locale/#' $(XPI_PATH)/chrome.manifest
-	sed -i -e 's#../common/#common/#' $(XPI_PATH)/chrome.manifest
+	sed -i'' -e 's# ./locale/# locale/#' $(XPI_PATH)/chrome.manifest
+	sed -i'' -e 's#../common/#common/#' $(XPI_PATH)/chrome.manifest
 
 	@echo "Replacing UUID, VERSION, DATE and UPDATEURL tags"
 	for file in `grep -rl -e "###UUID###" -e "###VERSION###" -e "###DATE###" $(XPI_PATH)` $(UPD_RDF_PATH); do \
-		sed -i -e "s,###UUID###,$(UUID),g" $${file}; \
-		sed -i -e "s,###VERSION###,$(VERSION),g" $${file}; \
-		sed -i -e "s,###MINVERSION###,$(MIN_VERSION),g" $${file}; \
-		sed -i -e "s,###MAXVERSION###,$(MAX_VERSION),g" $${file}; \
-		sed -i -e "s,###DATE###,$(BUILD_DATE),g" $${file}; \
-		sed -i -e "s,###UPDATEXPI###,$(UPDATE_URL_XPI),g" $${file}; \
+		sed -i'' -e "s,###UUID###,$(UUID),g" $${file}; \
+		sed -i'' -e "s,###VERSION###,$(VERSION),g" $${file}; \
+		sed -i'' -e "s,###MINVERSION###,$(MIN_VERSION),g" $${file}; \
+		sed -i'' -e "s,###MAXVERSION###,$(MAX_VERSION),g" $${file}; \
+		sed -i'' -e "s,###DATE###,$(BUILD_DATE),g" $${file}; \
+		sed -i'' -e "s,###UPDATEXPI###,$(UPDATE_URL_XPI),g" $${file}; \
 		if [ -n "$(UPDATE_URL)" ]; then \
-		    sed -i -e "s,###UPDATEURL###,$(UPDATE_URL),g" $${file}; \
+		    sed -i'' -e "s,###UPDATEURL###,$(UPDATE_URL),g" $${file}; \
 		else \
-		    sed -i -e "/###UPDATEURL###/d" $${file}; \
+		    sed -i'' -e "/###UPDATEURL###/d" $${file}; \
 		fi; \
 	done
 

--- a/common/Makefile
+++ b/common/Makefile
@@ -130,7 +130,7 @@ xpi:
 		if [ -n "$(UPDATE_URL)" ]; then \
 		    sed -i -e "s,###UPDATEURL###,$(UPDATE_URL),g" $${file}; \
 		else \
-		    sed -i "/###UPDATEURL###/d" $${file}; \
+		    sed -i -e "/###UPDATEURL###/d" $${file}; \
 		fi; \
 	done
 


### PR DESCRIPTION
On BSD flavours of `sed`, the argument to `-i` is non-optional. If no explicit empty string argument is provided, the next token is consumed as the backup filename suffix and subsequent command-line tokens are mis-interpreted.

20cbcd7 "fixes" #648 by correcting a presumed typo that surfaced the problem. This allows `make xpi` to complete on BSD, albeit with a behaviour of `sed -i` inconsistent with GNU and likely not what is intended.

d36b6b4 fixes the underlying issue by supplying the filename suffix for `sed -i` explicitly.

