### PR TITLE
Remove uriIsPrefix (no longer supported)

### DIFF
--- a/common/content/bookmarks.js
+++ b/common/content/bookmarks.js
@@ -737,7 +737,9 @@ const Bookmarks = Module("bookmarks", {
                     context.generate = function () {
                         let [begin, end] = item.url.split("%s");
 
-                        return history.get({ uri: window.makeURI(begin), uriIsPrefix: true }).map(function (item) {
+                        return history.get({ domain: window.makeURI(begin).hostname, domainIsHost: true }).filter(function (item) {
+                            return item.url.startsWith(begin);
+                        }).map(function (item) {
                             let rest = item.url.length - end.length;
                             let query = item.url.substring(begin.length, rest);
                             if (item.url.substr(rest) == end && query.indexOf("&") == -1) {

--- a/common/content/bookmarks.js
+++ b/common/content/bookmarks.js
@@ -737,7 +737,7 @@ const Bookmarks = Module("bookmarks", {
                     context.generate = function () {
                         let [begin, end] = item.url.split("%s");
 
-                        return history.get({ domain: window.makeURI(begin).hostname, domainIsHost: true }).filter(function (item) {
+                        return history.get({ domain: window.makeURI(begin).host, domainIsHost: true }).filter(function (item) {
                             return item.url.startsWith(begin);
                         }).map(function (item) {
                             let rest = item.url.length - end.length;

--- a/common/content/history.js
+++ b/common/content/history.js
@@ -18,6 +18,16 @@ const History = Module("history", {
         if (typeof filter == "string")
             filter = { searchTerms: filter };
 
+        try {
+            for (let k in filter) {
+                if (filter.hasOwnProperty(k)) {
+                    query[k] = filter[k];
+                }
+            }
+        } catch (e) {
+            // ?
+        }
+
         options.sortingMode = options.SORT_BY_DATE_DESCENDING;
         options.resultType = options.RESULTS_AS_URI;
         if (maxItems > 0)


### PR DESCRIPTION
Fixes #654.

I'm not 100% certain that I'm handling URIs vs URLs strictly correctly here.

It appears to fix the problem for me - with this fix, the interface is (mostly) responsive while typing (pauses for at most 1 sec, usually the first time after loading FF, and certainly not up to 5 or more secs like previously), and the results are correctly just the relevant historical quick searches for the keyword URL.

Please review and adjust as necessary.