### PR TITLE
nsITransferable must be initialized before use. Fixes vimperator/vimperator-labs#660

### DIFF
--- a/common/content/util.js
+++ b/common/content/util.js
@@ -663,6 +663,9 @@ const Util = Module("util", {
         try {
             const clipboard = Cc["@mozilla.org/widget/clipboard;1"].getService(Ci.nsIClipboard);
             const transferable = Cc["@mozilla.org/widget/transferable;1"].createInstance(Ci.nsITransferable);
+            if("init" in transferable) {
+                transferable.init(null);
+            }
 
             transferable.addDataFlavor("text/unicode");
 


### PR DESCRIPTION
a nsITransferable must be initialized before use, otherwise firefox crashes due to a failed assertion.
This fixes issue vimperator/vimperator-labs#660.