### PR TITLE
Fix #666: Remove deprecated canClear function

### DIFF
--- a/common/content/sanitizer.js
+++ b/common/content/sanitizer.js
@@ -43,7 +43,7 @@ const Sanitizer = Module("sanitizer", {
         for (let itemName in this.items) {
             let item = this.items[itemName];
 
-            if ("clear" in item && item.canClear && prefSet(itemName)) {
+            if ("clear" in item && prefSet(itemName)) {
                 liberator.echomsg("Sanitizing " + itemName + " items...");
                 // Some of these clear() may raise exceptions (see bug #265028)
                 // to sanitize as much as possible, we catch and store them,
@@ -176,7 +176,6 @@ const Sanitizer = Module("sanitizer", {
                 options.setPref(pref, false);
 
             self.items[item.name] = {
-                canClear: true,
                 clear: item.action
             };
         });


### PR DESCRIPTION
This PR fixes #666, which was caused by the removal of the `canClear` from items in sanitize.js (See Firefox [#1211849](https://bugzilla.mozilla.org/show_bug.cgi?id=1211849))

This PR has been tested on the current Firefox ESR version. It causes no new errors or issues in terms of functionality.

The issues seen in #208 are also fixed with this PR, though it would appear that some issues in the bug report were fixed prior.