### PR TITLE
"Preferences" button now opens options help page

### DIFF
--- a/vimperator/install.rdf
+++ b/vimperator/install.rdf
@@ -12,7 +12,8 @@
         <em:creator>Martin Stubenschrott</em:creator>
         <em:homepageURL>http://vimperator.org</em:homepageURL>
         <em:iconURL>chrome://vimperator/skin/icon.png</em:iconURL>
-        <em:optionsURL>chrome://liberator/content/preferences.xul</em:optionsURL>
+        <em:optionsType>3</em:optionsType>
+        <em:optionsURL>liberator://help/options</em:optionsURL>
         <em:updateURL>###UPDATEURL###</em:updateURL>
         <em:targetApplication>
             <Description>


### PR DESCRIPTION
The Vimperator "Preferences" button on the Firefox Add-ons page now
opens the options help page in a new tab.

I changed the `optionsURL` to the "options" help page and changed the
`optionsType` to `3`, which means:
> Opens optionsURL in a new tab (if the application supports that), or a
> dialog box

See here for documentation:
https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#optionsType

Before, the button did not do anything.

Fixes #574 

If you want me to remove the "Preferences" button completely instead, that would be easily possible. Just let me know.