### PR TITLE
Fix #718: Do not call `_processHints` after following a unique hint.

### DIFF
--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -647,13 +647,19 @@ const Hints = Module("hints", {
         return true;
     },
 
+    /**
+     * Checks whether the current _hintNumber uniquely identifies a hint and if yes, follows it.
+     * If not, but options.hinttimeout is set, follows the hint after a timeout.
+     *
+     * @return whether a unique hint was found and followed without a timeout.
+     */
     _checkUnique: function () {
         if (
             this._hintNumber === null ||
             this._hintNumber === 0 ||
             this._hintNumber > this._validHints.length
         ) {
-            return;
+            return false;
         }
 
         // if we write a numeric part like 3, but we have 45 hints, only follow
@@ -662,9 +668,12 @@ const Hints = Module("hints", {
             let timeout = options.hinttimeout;
             if (timeout > 0)
                 this._activeTimeout = this.setTimeout(function () { this._processHints(true); }, timeout);
+            return false;
         }
-        else // we have a unique hint
+        else { // we have a unique hint
             this._processHints(true);
+            return true;
+        }
     },
 
     /**
@@ -1075,7 +1084,9 @@ const Hints = Module("hints", {
 
             this._showActiveHint(this._hintNumber, oldHintNumber || 1);
 
-            this._checkUnique();
+            if (this._checkUnique()) {
+                return;
+            }
         }
 
         this._updateStatusline();

--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -650,7 +650,7 @@ const Hints = Module("hints", {
     _checkUnique: function () {
         if (
             this._hintNumber === null ||
-            this._hintNumber === this._chars2num(options.hintchars[0]) ||
+            this._hintNumber === 0 ||
             this._hintNumber > this._validHints.length
         ) {
             return;
@@ -658,7 +658,7 @@ const Hints = Module("hints", {
 
         // if we write a numeric part like 3, but we have 45 hints, only follow
         // the hint after a timeout, as the user might have wanted to follow link 34
-        if (this._hintNumber > 0 && this._hintNumber * options.hintchars.length <= this._validHints.length) {
+        if (this._hintNumber * options.hintchars.length <= this._validHints.length) {
             let timeout = options.hinttimeout;
             if (timeout > 0)
                 this._activeTimeout = this.setTimeout(function () { this._processHints(true); }, timeout);


### PR DESCRIPTION
When following a unique hint, the `_validHints` array is cleared, thus
the second call of `_processHints` triggers a `beep()` after
following a hint.