### PR TITLE
Fix #731: Remove Invalid Reference to Function

### DIFF
--- a/common/content/finder.js
+++ b/common/content/finder.js
@@ -270,8 +270,6 @@ var Finder = Module("finder", {
         }
 
         btn.checked = true;
-
-        findbar._setHighlightTimeout();
     },
 
     /**


### PR DESCRIPTION
This patch removes the reference to a `findbar._setHighlightTimeout` function, which isn't defined (anymore?) and causes an error message when invoking the find on page function.