### PR TITLE
Disable urlseparator by default, for #319

### DIFF
--- a/common/content/browser.js
+++ b/common/content/browser.js
@@ -57,7 +57,7 @@ const Browser = Module("browser", {
 
         options.add(["urlseparator"],
             "Set the separator regex used to separate multiple URL args",
-            "string", ",\\s");
+            "string", "");
 
         options.add(["yankencodedurl"],
             "Set the yank mode copying encoded URL",

--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -1,7 +1,7 @@
 201x-xx-xx:
     * create README.md
     * fix search highlighting (hlsearch) in firefox 51
-
+    * disable urlseparator by default as its unexpected behaviour irritates users
 
 2017-02-01:
     * add option 'newtaburl' to set default URL in new tabs


### PR DESCRIPTION
As explained in #319, the current urlseparator `",\s+"` is too common in URLs and search strings to be a sensible default separator.
* When copying and pasting some content to look it up with some search engine (for instance a title or an address):
`:open google gödel, escher, bach`
`:open duckduckgo 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA` 
* A comma followed by spaces is also legitimate in a URL! For instance if you put some JSON as a GET parameter in a URL.
`:open http://refine.codefork.com/reconcile/viaf?query={"query": "Scott Aaronson", "type": "/people/person"}`

Therefore I propose to disable this option by default and let users enable it with their preferred separator.

@tot-to, @maxauthority do you support this PR?