### PR TITLE
Try translating "next"/"previous" links to history commands

### DIFF
--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -592,6 +592,19 @@ const Buffer = Module("buffer", {
                     let elem = res.snapshotItem(i);
                     if (regex.test(elem.textContent) || regex.test(elem.title) ||
                             Array.some(elem.childNodes, function (child) regex.test(child.alt))) {
+                        if (elem.href
+                            && typeof history.session[history.session.index - 1] !== "undefined"
+                            && history.session[history.session.index - 1].URI.spec === elem.href) {
+                            history.stepTo(-1);
+                            return true;
+                        }
+                        if (elem.href
+                            && typeof history.session[history.session.index + 1] !== "undefined"
+                            && history.session[history.session.index + 1].URI.spec === elem.href) {
+                            history.stepTo(1);
+                            return true;
+                        }
+
                         buffer.followLink(elem, liberator.CURRENT_TAB);
                         return true;
                     }


### PR DESCRIPTION
Going forward and back in the pages of a search result creates a huge trail of history which is repetitive. For example consider the case:

- we are on example.com
- we do a google search 
- hit: `]]`  x3, then `[[` x2 then `]]` x7 then `[[` x8

We are now on page 1 but we are 19 history items away from example.com. It would be reasonable (and at times faster) `]]` and to navigate history instead of click the links.