### PR TITLE
Remove usage of nsISupportsArray

### DIFF
--- a/common/content/liberator.js
+++ b/common/content/liberator.js
@@ -846,14 +846,14 @@ const Liberator = Module("liberator", {
 
                 case liberator.NEW_PRIVATE_WINDOW:
                 case liberator.NEW_WINDOW:
-                    let sa = Cc["@mozilla.org/supports-array;1"].createInstance(Ci.nsISupportsArray);
+                    let sa = Cc["@mozilla.org/array;1"].createInstance(Ci.nsIMutableArray);
                     let wuri = Cc["@mozilla.org/supports-string;1"].createInstance(Ci.nsISupportsString);
                     wuri.data = url;
-                    sa.AppendElement(wuri);
-                    sa.AppendElement(null); // charset
-                    sa.AppendElement(null); // referrerURI
-                    sa.AppendElement(postdata);
-                    sa.AppendElement(null); // allowThirdPartyFixup
+                    sa.appendElement(wuri, false);
+                    sa.appendElement(null, false); // charset
+                    sa.appendElement(null, false); // referrerURI
+                    sa.appendElement(postdata, false);
+                    sa.appendElement(null, false); // allowThirdPartyFixup
 
                     let features = "chrome,dialog=no,all" + (where === liberator.NEW_PRIVATE_WINDOW ? ",private" : "");
                     let win = services.get("ww").openWindow(window, "chrome://browser/content/browser.xul", null, features, sa);


### PR DESCRIPTION
With FF55 no new windows could be opened with `:winopen`.

nsISupportsArray was deprecated a long time ago and finally removed in
Firefox 55 (see https://bugzilla.mozilla.org/show_bug.cgi?id=792209).

This should be backwards compatible, but was only tested against FF55.